### PR TITLE
Fixed a bug where field names weren't being applied to arguments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-version = "0.5.1"
+version = "0.5.0"
 
 idea {
     project {

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven'
 apply plugin: 'maven-publish'
 
-version = "0.5.0"
+version = "0.5.1"
 
 idea {
     project {

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -253,6 +253,10 @@ public class GraphQLAnnotations {
         if (defaultValue != null) {
             builder.defaultValue(defaultValue.value().newInstance().get());
         }
+        GraphQLName name = parameter.getAnnotation(GraphQLName.class);
+        if ( name != null ) {
+            builder.name(name.value());
+        }
         return builder.build();
     }
 

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -82,6 +82,26 @@ public class GraphQLObjectTest {
     private static class TestDefaults {
     }
 
+    private static class TestObjectNamedArgs {
+        @GraphQLField
+        public String fieldWithNamedArgs(@GraphQLName("namedArg") String firstArgument) {
+            return firstArgument;
+        }
+    }
+
+    @Test @SneakyThrows
+    public void namedFields() {
+        GraphQLObjectType object = GraphQLAnnotations.object(TestObjectNamedArgs.class);
+        List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
+        assertEquals(fields.size(), 1);
+
+        List<GraphQLArgument> args = fields.get(0).getArguments();
+        assertEquals(args.size(), 1);
+
+        GraphQLArgument arg = args.get(0);
+        assertEquals(arg.getName(), "namedArg");
+    }
+
     @Test @SneakyThrows
     public void metainformation() {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObject.class);


### PR DESCRIPTION
Arguments for GraphQL fields were being parsed as arg0, arg1, etc.  This change will override the argument/field name if "@GraphQLName" is provided in the method parameters.
