### PR TITLE
Fixup processing of @GraphQLConnection to not inline fields

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -202,7 +202,7 @@ public class GraphQLAnnotations {
                 String annValue = field.getAnnotation(GraphQLConnection.class).name();
                 String connectionName = annValue.isEmpty() ? wrappedType.getName() : annValue;
                 Relay relay = new Relay();
-                GraphQLObjectType edgeType = relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, ((GraphQLObjectType) wrappedType).getFieldDefinitions());
+                GraphQLObjectType edgeType = relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList());
                 outputType = relay.connectionType(connectionName, edgeType, Collections.emptyList());
                 builder.argument(relay.getConnectionFieldArguments());
             }


### PR DESCRIPTION
The definition for edge types in the relay spec is they must have fields named node and cursor, but may have additional fields related to the edge. The current call to relay.edgeType adds in all the fields of the node type, which seems incorrect, as they are present under the node field and are not loaded from it by the underlying graphql-java library.

https://facebook.github.io/relay/graphql/connections.htm

This pull uses the same method as the todomvc example from the graphql-java readme to pass in an empty list of additional fields, to remove the duplication of the fields from the node.

https://github.com/andimarek/todomvc-relay-java/blob/5c37d571a77bf88e02598f916515374fdceb5b45/src/main/java/todomvc/TodoSchema.java#L153
