### PR TITLE
Add @GraphQLInvokeDetached for top-level methods

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -389,7 +389,6 @@ public class GraphQLAnnotations {
 
     protected static GraphQLArgument argument(Parameter parameter, graphql.schema.GraphQLType t) throws IllegalAccessException, InstantiationException {
         GraphQLArgument.Builder builder = newArgument();
-        builder.name(parameter.getName());
         builder.type(parameter.getAnnotation(NotNull.class) == null ? (GraphQLInputType) t : new graphql.schema.GraphQLNonNull(t));
         GraphQLDescription description = parameter.getAnnotation(GraphQLDescription.class);
         if (description != null) {
@@ -402,6 +401,8 @@ public class GraphQLAnnotations {
         GraphQLName name = parameter.getAnnotation(GraphQLName.class);
         if ( name != null ) {
             builder.name(name.value());
+        } else {
+            builder.name(parameter.getName());
         }
         return builder.build();
     }

--- a/src/main/java/graphql/annotations/GraphQLInvokeDetached.java
+++ b/src/main/java/graphql/annotations/GraphQLInvokeDetached.java
@@ -1,0 +1,28 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Created by ngoel on 5/31/16.
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLInvokeDetached {
+}

--- a/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
+++ b/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.schema.GraphQLObjectType;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.SneakyThrows;
+import org.testng.annotations.Test;
+
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Created by ngoel on 5/31/16.
+ */
+public class GraphQLSimpleSchemaTest {
+
+    public static class User {
+
+        @Getter
+        @Setter
+        private String name;
+
+        @GraphQLField
+        public String name() {
+            return this.getName();
+        }
+    }
+
+
+    public static class Query {
+        @GraphQLInvokeDetached
+        @GraphQLField
+        public User defaultUser() {
+            User user = new User();
+            user.setName("Test Name");
+            return user;
+        }
+    }
+
+    @Test @SneakyThrows
+    public void detachedCall() {
+        GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
+        GraphQL graphql = new GraphQL(newSchema().query(queryObject).build());
+
+        ExecutionResult result = graphql.execute("{ defaultUser{ name } }");
+        String actual = result.getData().toString();
+        assertEquals(actual, "{defaultUser={name=Test Name}}");
+    }
+}
+


### PR DESCRIPTION
When methods are defined in a class, they are always invoked on `environment.getSource()`.
Further, the `MethodDataFetcher` starts with `if (environment.getSource() == null) return null;` which means that any top level Object Type, namely `Query` and `Mutation` cannot be declared as classes with inline methods.

This pull request adds a new annotation for methods, `GraphQLInvokeDetached` that will invoke the method even if `environment.getSource` is null. This cleans up the code and saves you from writing separate DataFetcher implementations for all top level fields.

There is a small test file as well.

PS. fixed a bug where the argument names would sometimes not be picked up automatically, and instead fall back to `arg0` etc.
