### PR TITLE
change target of GraphQLType to FIELD and METHOD

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLType.java
+++ b/src/main/java/graphql/annotations/GraphQLType.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target(ElementType.TYPE_USE)
+@Target({ElementType.METHOD, ElementType.FIELD})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLType {
     Class<? extends TypeFunction> value() default DefaultTypeFunction.class;


### PR DESCRIPTION
I had to change the target of the annotation to make it recognizable for a method or field so I could assign a specific TypeFunction for the field or method.
