### PR TITLE
Register double as a default type for Scalars.GraphQLFloat.

### DIFF
--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -206,6 +206,8 @@ public class DefaultTypeFunction implements TypeFunction {
 
         register(Float.class, new FloatFunction());
         register(float.class, new FloatFunction());
+        register(Double.class, new FloatFunction());
+        register(double.class, new FloatFunction());
 
         register(Integer.class, new IntegerFunction());
         register(int.class, new IntegerFunction());

--- a/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
+++ b/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
@@ -66,6 +66,8 @@ public class DefaultTypeFunctionTest {
     public void float_() {
         assertEquals(instance.apply(float.class, null), GraphQLFloat);
         assertEquals(instance.apply(Float.class, null), GraphQLFloat);
+        assertEquals(instance.apply(Double.class, null), GraphQLFloat);
+        assertEquals(instance.apply(double.class, null), GraphQLFloat);
     }
 
     @Test


### PR DESCRIPTION
I've noticed that `graphql-java-annotations` is not able to infer GraphQL types for `Double` and `double` fields. The GraphQL standard doesn't define a `Double` value, it only defines a `Float`. However, `graphql-java` uses `Double` as base type for `Scalars.GraphQLFloat`.

Given that `double` is a primitive type of Java, I think it makes sense to register it in `graphql-java-annotations` by default.
