### PR TITLE
Added support for method Batched Data Fetcher

### DIFF
--- a/src/main/java/graphql/annotations/BatchedMethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/BatchedMethodDataFetcher.java
@@ -1,0 +1,24 @@
+package graphql.annotations;
+
+import graphql.execution.batched.Batched;
+import graphql.schema.DataFetchingEnvironment;
+import lombok.SneakyThrows;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+
+public class BatchedMethodDataFetcher extends MethodDataFetcher {
+    public BatchedMethodDataFetcher(Method method) {
+        super(method);
+        if (!Modifier.isStatic(method.getModifiers())) {
+            throw new IllegalArgumentException("Batched method should be static");
+        }
+    }
+
+    @SneakyThrows
+    @Batched
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        return super.get(environment);
+    }
+}

--- a/src/main/java/graphql/annotations/BatchedMethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/BatchedMethodDataFetcher.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import graphql.execution.batched.Batched;

--- a/src/main/java/graphql/annotations/BatchedTypeFunction.java
+++ b/src/main/java/graphql/annotations/BatchedTypeFunction.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import graphql.schema.GraphQLList;

--- a/src/main/java/graphql/annotations/BatchedTypeFunction.java
+++ b/src/main/java/graphql/annotations/BatchedTypeFunction.java
@@ -1,0 +1,35 @@
+package graphql.annotations;
+
+import graphql.schema.GraphQLList;
+
+import java.lang.reflect.AnnotatedParameterizedType;
+import java.lang.reflect.AnnotatedType;
+import java.lang.reflect.ParameterizedType;
+import java.util.List;
+
+public class BatchedTypeFunction implements TypeFunction {
+    private TypeFunction defaultTypeFunction;
+
+    public BatchedTypeFunction(TypeFunction defaultTypeFunction) {
+        this.defaultTypeFunction = defaultTypeFunction;
+    }
+
+    @Override
+    public graphql.schema.GraphQLType apply(Class<?> aClass, AnnotatedType annotatedType) {
+        if (!aClass.isAssignableFrom(List.class)) {
+            throw new IllegalArgumentException("Batched method should return a List");
+        }
+        if (!(annotatedType instanceof AnnotatedParameterizedType)) {
+            throw new IllegalArgumentException("Batched should return parameterized type");
+        }
+        AnnotatedParameterizedType parameterizedType = (AnnotatedParameterizedType) annotatedType;
+        AnnotatedType arg = parameterizedType.getAnnotatedActualTypeArguments()[0];
+        Class<?> klass;
+        if (arg.getType() instanceof ParameterizedType) {
+            klass = (Class<?>)((ParameterizedType)(arg.getType())).getRawType();
+        } else {
+            klass = (Class<?>) arg.getType();
+        }
+        return defaultTypeFunction.apply(klass, arg);
+    }
+}

--- a/src/main/java/graphql/annotations/GraphQLBatched.java
+++ b/src/main/java/graphql/annotations/GraphQLBatched.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/graphql/annotations/GraphQLBatched.java
+++ b/src/main/java/graphql/annotations/GraphQLBatched.java
@@ -1,0 +1,11 @@
+package graphql.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLBatched {
+}

--- a/src/test/java/graphql/annotations/GraphQLBatchedTest.java
+++ b/src/test/java/graphql/annotations/GraphQLBatchedTest.java
@@ -1,0 +1,98 @@
+package graphql.annotations;
+
+import graphql.ExceptionWhileDataFetching;
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.execution.batched.BatchedExecutionStrategy;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import lombok.SneakyThrows;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.annotations.DefaultTypeFunction.instance;
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class GraphQLBatchedTest {
+    private static class SimpleBatchedField {
+        @GraphQLField
+        @GraphQLBatched
+        public static List<String> a() {
+            return Arrays.asList("one", "two");
+        }
+    }
+
+    private static class TestBatchedObject {
+        @GraphQLField
+        public List<SimpleBatchedField> fields() {
+            return Arrays.asList(new SimpleBatchedField(), new SimpleBatchedField());
+        }
+    }
+
+    @Test
+    @SneakyThrows
+    public void batchedDataFetcher() {
+        GraphQLObjectType nestedObject = GraphQLAnnotations.object(SimpleBatchedField.class);
+        assertEquals(nestedObject.getFieldDefinition("a").getType(), GraphQLString);
+
+        GraphQLObjectType object = GraphQLAnnotations.object(TestBatchedObject.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+        GraphQL graphql = new GraphQL(schema, new BatchedExecutionStrategy());
+        ExecutionResult result = graphql.execute("{ fields { a } }", new TestBatchedObject());
+        List errors = result.getErrors();
+        for (Object e : errors) {
+            throw ((ExceptionWhileDataFetching) e).getException();
+        }
+        assertTrue(result.getErrors().isEmpty());
+        Map<String, Object> data = (Map) result.getData();
+        List<Map<String, Object>> fields = (List) data.get("fields");
+        assertEquals(fields.get(0).get("a"), "one");
+        assertEquals(fields.get(1).get("a"), "two");
+    }
+
+    private static class NoStaticBatchedField {
+        @GraphQLField
+        @GraphQLBatched
+        public List<String> a() {
+            return Arrays.asList("one", "two");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class) @SneakyThrows
+    public void noStaticField() {
+        GraphQLObjectType object = GraphQLAnnotations.object(NoStaticBatchedField.class);
+    }
+
+    private static class NoListBatchedField {
+        @GraphQLField
+        @GraphQLBatched
+        public String a() {
+            return "one";
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class) @SneakyThrows
+    public void noListField() {
+        GraphQLObjectType object = GraphQLAnnotations.object(NoStaticBatchedField.class);
+    }
+
+    private static class NoParameterizedBatchedField {
+        @GraphQLField
+        @GraphQLBatched
+        public List a() {
+            return Arrays.asList("one", "two");
+        }
+    }
+
+    @Test(expectedExceptions = IllegalArgumentException.class) @SneakyThrows
+    public void noParameterizedReturnField() {
+        GraphQLObjectType object = GraphQLAnnotations.object(NoStaticBatchedField.class);
+    }
+}

--- a/src/test/java/graphql/annotations/GraphQLBatchedTest.java
+++ b/src/test/java/graphql/annotations/GraphQLBatchedTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import graphql.ExceptionWhileDataFetching;


### PR DESCRIPTION
This fixes #24.

This change allows methods to be used as Batched data fetchers. Now it's possible to write batched queries like this:

``` java
    public class SimpleBatchedField {
        @GraphQLField
        @GraphQLBatched
        public static List<String> a() {
            return Arrays.asList("one", "two");
        }
    }
```

A method with the `@GraphQLBatched` annotation should always return a list. It also has to be static, because it won't operate on a single object but a list of objects, which should be obtained from the DataFetchingEnvironment.
