### PR TITLE
@GraphQLField for private field also

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -200,7 +200,7 @@ public class GraphQLAnnotations {
                 builder.field(field(method));
             }
         }
-        for (Field field : object.getFields()) {
+        for (Field field : object.getDeclaredFields() ) {
             boolean valid = !Modifier.isStatic(field.getModifiers()) &&
                     field.getAnnotation(GraphQLField.class) != null;
             if (valid) {


### PR DESCRIPTION
It's now possibly to add annotations on private field, so you don't have to add them to getters / setters.
More brettyer way.

example:

public class Testtable {

  @GraphQLField
  private String name;

  public String getName() {
    return name;
  }

  public void setName(String name) {
    this.name = name;
  }
}
