### PR TITLE
private field was still broken, fixed it and added data fetch tests.

### DIFF
--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -156,6 +156,9 @@ public class GraphQLObjectTest {
         assertEquals(fields.get(5).getName(), "privateTest");
         assertEquals(fields.get(6).getName(), "publicTest");
 
+        assertEquals(fields.get(5).getDataFetcher().getClass(), PropertyDataFetcher.class);
+        assertEquals(fields.get(6).getDataFetcher().getClass(), FieldDataFetcher.class);
+
     }
 
     private static class TestObjectInherited extends TestObject {
@@ -231,6 +234,19 @@ public class GraphQLObjectTest {
     public static class TestField {
         @GraphQLField @GraphQLName("field1")
         public String field = "test";
+    }
+
+    public static class PrivateTestField {
+
+        @Getter
+        @Setter
+        @GraphQLField @GraphQLName("field1")
+        private String field = "test";
+
+        @Getter
+        @Setter
+        @GraphQLField
+        private boolean booleanField = true;
     }
 
     @Test @SneakyThrows
@@ -313,6 +329,18 @@ public class GraphQLObjectTest {
         ExecutionResult result = new GraphQL(schema).execute("{field1}", new TestField());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>)result.getData()).get("field1"), "test");
+    }
+
+    @Test @SneakyThrows
+    public void queryPrivateField() {
+        GraphQLObjectType object = GraphQLAnnotations.object(PrivateTestField.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+
+        ExecutionResult result = new GraphQL(schema).execute("{field1, booleanField}", new PrivateTestField());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, String>)result.getData()).get("field1"), "test");
+        assertTrue(((Map<String, Boolean>)result.getData()).get("booleanField"));
+
     }
 
     @Test @SneakyThrows


### PR DESCRIPTION
I thought that it was using propertyDataGetter for fields (what tryis getter and then fallbacks to field), but it was using fieldDataGetter.
Added some logic which is trying to decide which one to use.

Basic idea on this change is that, if there is getter, use PropertyDataGetter. Otherwise use filedDataGetter directly.
