### PR TITLE
Problem: extending generic class duplicate field definition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.iml
 *.ipr
 *.iws
+/.nb-gradle/

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -200,8 +200,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
             Class<?> declaringClass = getDeclaringClass(method);
 
-            boolean valid = (method.getAnnotation(GraphQLField.class) != null ||
-                     declaringClass.getMethod(method.getName(), method.getParameterTypes()).getAnnotation(GraphQLField.class) != null);
+            boolean valid =  (method.getAnnotation(GraphQLField.class) != null ||
+                     declaringClass.getMethod(method.getName(), method.getParameterTypes()).getAnnotation(GraphQLField.class) != null)
+                    && !method.isBridge();
 
             if (valid) {
                 builder.field(getField(method));

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -188,6 +188,38 @@ public class GraphQLObjectTest {
         assertEquals(((Map<String, Object>)result.getData()).get("field1"), "inherited");
     }
 
+    private static class TestObjectBridgMethodParent<Type> {
+        private final Type id;
+        public TestObjectBridgMethodParent(Type id) {
+            this.id = id;
+        }
+        public Type id() {
+            return id;
+        }
+    }
+    
+    private static class TestObjectBridgMethod extends TestObjectBridgMethodParent<Long> {
+
+        public TestObjectBridgMethod() {
+            super(1l);
+        }
+        
+        @Override @GraphQLField
+        public Long id() {
+            return super.id();
+        }
+    }
+    
+    @Test @SneakyThrows
+    public void methodInheritanceWithGenerics() {
+        GraphQLObjectType object = GraphQLAnnotations.object(TestObjectBridgMethod.class);
+
+        GraphQLSchema schema = newSchema().query(object).build();
+
+        ExecutionResult result = new GraphQL(schema).execute("{id}", new TestObjectBridgMethod());
+        assertEquals(((Map<String, Object>)result.getData()).get("id"), 1l);
+    }
+    
     public interface Iface {
         @GraphQLField
         default String field() {


### PR DESCRIPTION
Solution: exclude bridge methods