### PR TITLE
Issue 40 runtime exceptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 *.ipr
 *.iws
 /.nb-gradle/
+.idea

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsException.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsException.java
@@ -1,0 +1,25 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+/**
+ * A base class for runtime exceptions that can happen during annotation introspection
+ */
+public class GraphQLAnnotationsException extends RuntimeException {
+    public GraphQLAnnotationsException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+}

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -21,33 +21,71 @@ import graphql.schema.GraphQLUnionType;
 
 public interface GraphQLAnnotationsProcessor {
     /**
-     * @param iface interface
-     * @return
-     * @throws IllegalAccessException
-     * @throws InstantiationException
-     * @throws IllegalArgumentException if <code>iface</code> is not an interface or doesn't have <code>@GraphTypeResolver</code> annotation
+     * This will examine the class and if its annotated with {@link GraphQLUnion} it will return
+     * a {@link GraphQLUnionType.Builder}, if its annotated with {@link GraphQLTypeResolver} it will return
+     * a {@link GraphQLObjectType} otherwise it will return a {@link GraphQLInterfaceType.Builder}.
+     *
+     * @param iface interface to examine
+     *
+     * @return a GraphQLType that represents that interface
+     *
+     * @throws GraphQLAnnotationsException if the interface cannot be examined
+     * @throws IllegalArgumentException    if <code>iface</code> is not an interface
      */
-    graphql.schema.GraphQLType getInterface(Class<?> iface)
-            throws IllegalAccessException, InstantiationException, NoSuchMethodException;
-
-    GraphQLUnionType.Builder getUnionBuilder(Class<?> iface) throws InstantiationException,
-                                                                    IllegalAccessException;
-
-    GraphQLInterfaceType.Builder getIfaceBuilder(Class<?> iface) throws InstantiationException,
-                                                                        IllegalAccessException;
+    graphql.schema.GraphQLType getInterface(Class<?> iface) throws GraphQLAnnotationsException;
 
     /**
-     * @param object
-     * @return
-     * @throws IllegalAccessException
-     * @throws InstantiationException
-     * @throws NoSuchMethodException
+     * This will examine the class and return a {@link GraphQLUnionType.Builder} ready for further definition
+     *
+     * @param iface interface to examine
+     *
+     * @return a {@link GraphQLUnionType.Builder}
+     *
+     * @throws GraphQLAnnotationsException if the class cannot be examined
+     * @throws IllegalArgumentException    if <code>iface</code> is not an interface
      */
-    GraphQLObjectType getObject(Class<?> object) throws IllegalAccessException, InstantiationException,
-                                                        NoSuchMethodException;
+    GraphQLUnionType.Builder getUnionBuilder(Class<?> iface) throws GraphQLAnnotationsException, IllegalArgumentException;
 
-    GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws NoSuchMethodException,
-                                                                       InstantiationException, IllegalAccessException;
+    /**
+     * This will examine the class and return a {@link GraphQLInterfaceType.Builder} ready for further definition
+     *
+     * @param iface interface to examine
+     *
+     * @return a {@link GraphQLInterfaceType.Builder}
+     *
+     * @throws GraphQLAnnotationsException if the class cannot be examined
+     * @throws IllegalArgumentException    if <code>iface</code> is not an interface
+     */
+    GraphQLInterfaceType.Builder getIfaceBuilder(Class<?> iface) throws GraphQLAnnotationsException, IllegalArgumentException;
 
+    /**
+     * This will examine the object class and return a {@link GraphQLObjectType} representation
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLObjectType} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLObjectType getObject(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
+     * This will examine the object class and return a {@link GraphQLObjectType.Builder} ready for further definition
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLObjectType.Builder} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
+     * This will turn a {@link GraphQLObjectType} into a corresponding {@link GraphQLInputObjectType}
+     *
+     * @param graphQLType the graphql object type
+     *
+     * @return a {@link GraphQLInputObjectType}
+     */
     GraphQLInputObjectType getInputObject(GraphQLObjectType graphQLType);
 }

--- a/src/main/java/graphql/annotations/GraphQLConnection.java
+++ b/src/main/java/graphql/annotations/GraphQLConnection.java
@@ -32,14 +32,14 @@ public @interface GraphQLConnection {
     /**
      * By default, a simple List connection is specified, but can be overridden using
      * this property to allow for more efficient fetching procedures (limiting database queries, etc.)
-     * @return
+     * @return a connection class
      */
     Class<? extends Connection> connection() default DispatchingConnection.class;
 
     /**
      * By default, wrapped type's name is used for naming TypeConnection, but can be overridden
      * using this property
-     * @return
+     * @return the wrapped type's name
      */
     String name() default "";
 }

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -36,7 +36,6 @@ public class GraphQLInterfaceTest {
     }
 
     @Test
-    @SneakyThrows
     public void noResolver() {
         GraphQLObjectType object = (GraphQLObjectType) GraphQLAnnotations.iface(NoResolverIface.class);
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
@@ -50,7 +49,7 @@ public class GraphQLInterfaceTest {
         public GraphQLObjectType getType(Object object) {
             try {
                 return GraphQLAnnotations.object(TestObject.class);
-            } catch (IllegalAccessException | InstantiationException | NoSuchMethodException e) {
+            } catch (GraphQLAnnotationsException e) {
                 return null;
             }
         }
@@ -89,7 +88,7 @@ public class GraphQLInterfaceTest {
         }
     }
 
-    @Test @SneakyThrows
+    @Test
     public void test() {
         GraphQLInterfaceType iface = (GraphQLInterfaceType) GraphQLAnnotations.iface(TestIface.class);
         List<GraphQLFieldDefinition> fields = iface.getFieldDefinitions();
@@ -97,14 +96,14 @@ public class GraphQLInterfaceTest {
         assertEquals(fields.get(0).getName(), "value");
     }
 
-    @Test @SneakyThrows
+    @Test
     public void testUnion() {
         GraphQLUnionType unionType = (GraphQLUnionType) GraphQLAnnotations.iface(TestUnion.class);
         assertEquals(unionType.getTypes().size(), 1);
         assertEquals(unionType.getTypes().get(0).getName(), "TestObject1");
     }
 
-    @Test @SneakyThrows
+    @Test
     public void testInterfaces() {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObject.class);
         List<GraphQLInterfaceType> ifaces = object.getInterfaces();
@@ -129,7 +128,7 @@ public class GraphQLInterfaceTest {
         @GraphQLField public TestUnion union;
     }
 
-    @Test @SneakyThrows
+    @Test
     public void query() {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
 
@@ -138,7 +137,7 @@ public class GraphQLInterfaceTest {
         assertEquals(((Map<String, Map<String, String>>)result.getData()).get("iface").get("value"), "a");
     }
 
-    @Test @SneakyThrows
+    @Test
     public void queryUnion() {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(UnionQuery.class)).build();
 


### PR DESCRIPTION
issue 40 - This uses a RuntimeException for nicer consumption and hence a number of 
the SneakyThrows can also be removed.

I also fixed a number of JavaDoc warnings which means the `gradle build` now gives not warnings for JavaDoc