### PR TITLE
Problem: GraphQLDataFetcher use with respect to field/property name's overly verbose/repetitive.

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 import java.util.TreeMap;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static graphql.Scalars.GraphQLBoolean;
 import static graphql.annotations.ReflectionKit.constructNewInstance;
@@ -326,7 +327,12 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         GraphQLDataFetcher dataFetcher = field.getAnnotation(GraphQLDataFetcher.class);
         DataFetcher actualDataFetcher = null;
         if (nonNull(dataFetcher)) {
-            final String[] args = dataFetcher.args();
+            final String[] args;
+            if ( dataFetcher.firstArgIsTargetName() ) {
+                args = Stream.concat(Stream.of(field.getName()), stream(dataFetcher.args())).toArray(String[]::new);
+            } else {
+                args = dataFetcher.args();
+            }
             if (args.length == 0) {
                 actualDataFetcher = newInstance(dataFetcher.value());
             } else {

--- a/src/main/java/graphql/annotations/GraphQLDataFetcher.java
+++ b/src/main/java/graphql/annotations/GraphQLDataFetcher.java
@@ -26,4 +26,5 @@ import java.lang.annotation.Target;
 public @interface GraphQLDataFetcher {
     Class<? extends DataFetcher> value();
     String[] args() default {};
+    boolean firstArgIsTargetName() default false;
 }


### PR DESCRIPTION
Problem: GraphQLDataFetcher use with respect to field/property name's overly verbose/repetitive.

Solution: Enhance the GraphQLDataFetcher annotation to optionally pass it's
target's name as the first 'arg' to the DataFetcher's constructor.