### PR TITLE
Update Type Inference docs (Issue #34)

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,21 @@ By default, standard GraphQL types (String, Integer, Long, Float, Boolean, Enum,
 
 Stream type is also supported and treated as a list.
 
-If you want to register an additional type (for example, UUID), you have to implement `TypeFunction` for it and register it with `DefaultTypeFunction`:
+If you want to register an additional type (for example, UUID), you have to create a new class implementing `TypeFunction` for it:
 
 ```java
-DefaultTypeFunction.register(UUID.class, new UUIDTypeFunction());
+public class UUIDTypeFunction implements TypeFunction {
+    ...
+}
+```
+
+And register it with `GraphQLAnnotations`:
+
+```java
+GraphQLAnnotations.register(new UUIDTypeFunction())
+
+// or if not using a static version of GraphQLAnnotations:
+// new GraphQLAnnotations().registerType(new UUIDTypeFunction())
 ```
 
 You can also specify custom type function for any field with `@GraphQLType` annotation.


### PR DESCRIPTION
The mechanism for registering custom type functions changed a long time ago, this brings the documentation up to date with those changes.