### PR TITLE
Support inheritence of GraphQLField annotation

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLField.java
+++ b/src/main/java/graphql/annotations/GraphQLField.java
@@ -19,7 +19,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.METHOD, ElementType.FIELD})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLField {
+  boolean value() default true;
 }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -46,6 +46,7 @@ import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
@@ -684,5 +685,30 @@ public class GraphQLObjectTest {
         assertEquals(((GraphQLList) t).getWrappedType(), Scalars.GraphQLString);
     }
 
+    @GraphQLField
+    public static class InheritGraphQLFieldTest {
+        public String inheritedOn;
+
+        @GraphQLField(false)
+        public String forcedOff;
+
+        public String getOn() {
+            return "on";
+        }
+
+        @GraphQLField(false)
+        public String getOff() {
+            return "off";
+        }
+    }
+
+    @Test
+    public void inheritGraphQLField() {
+        GraphQLObjectType object = GraphQLAnnotations.object(InheritGraphQLFieldTest.class);
+        assertNotNull(object.getFieldDefinition("on"));
+        assertNull(object.getFieldDefinition("off"));
+        assertNotNull(object.getFieldDefinition("inheritedOn"));
+        assertNull(object.getFieldDefinition("forcedOff"));
+    }
 
 }


### PR DESCRIPTION
Allow GraphQLField annotation on interfaces and classes.  All methods and fields 'inherit' GraphQLField annotation value.  Add a boolean parameter to the annotation to allow turning off at individual fields or methods or child class.