### PR TITLE
introduced typeRegistry for GraphQLType objects to prevent duplicate …

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -15,8 +15,22 @@
 package graphql.annotations;
 
 import graphql.relay.Relay;
-import graphql.schema.*;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.FieldDataFetcher;
+import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLInputObjectField;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLInputType;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLUnionType;
+import graphql.schema.PropertyDataFetcher;
+import graphql.schema.TypeResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -15,22 +15,8 @@
 package graphql.annotations;
 
 import graphql.relay.Relay;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.FieldDataFetcher;
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInputObjectField;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLList;
+import graphql.schema.*;
 import graphql.schema.GraphQLNonNull;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLUnionType;
-import graphql.schema.PropertyDataFetcher;
-import graphql.schema.TypeResolver;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
@@ -66,7 +52,6 @@ import static graphql.schema.GraphQLInterfaceType.newInterface;
 import static graphql.schema.GraphQLObjectType.newObject;
 import static graphql.schema.GraphQLUnionType.newUnionType;
 import static java.util.Arrays.stream;
-import static java.util.Objects.isNull;
 import static java.util.Objects.nonNull;
 
 /**
@@ -75,6 +60,8 @@ import static java.util.Objects.nonNull;
  */
 @Component
 public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
+
+    private Map<String, graphql.schema.GraphQLType> typeRegistry = new HashMap<>();
 
     public GraphQLAnnotations() {
         defaultTypeFunction = new DefaultTypeFunction();
@@ -89,13 +76,20 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
     @Override
     public graphql.schema.GraphQLType getInterface(Class<?> iface) throws GraphQLAnnotationsException {
-        if (iface.getAnnotation(GraphQLUnion.class) != null) {
-            return getUnionBuilder(iface).build();
-        } else if (!iface.isAnnotationPresent(GraphQLTypeResolver.class)) {
-            return getObject(iface);
-        } else {
-            return getIfaceBuilder(iface).build();
+        String typeName = getTypeName(iface);
+        graphql.schema.GraphQLType type = typeRegistry.get(typeName);
+        if (type != null) { // type already exists, do not build a new new one
+            return type;
         }
+        if (iface.getAnnotation(GraphQLUnion.class) != null) {
+            type = getUnionBuilder(iface).build();
+        } else if (!iface.isAnnotationPresent(GraphQLTypeResolver.class)) {
+            type = getObject(iface);
+        } else {
+            type = getIfaceBuilder(iface).build();
+        }
+        typeRegistry.put(typeName, type);
+        return type;
     }
 
     public static graphql.schema.GraphQLType iface(Class<?> iface) throws GraphQLAnnotationsException {
@@ -110,8 +104,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         GraphQLUnionType.Builder builder = newUnionType();
 
         GraphQLUnion unionAnnotation = iface.getAnnotation(GraphQLUnion.class);
-        GraphQLName name = iface.getAnnotation(GraphQLName.class);
-        builder.name(name == null ? iface.getSimpleName() : name.value());
+        builder.name(getTypeName(iface));
         GraphQLDescription description = iface.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());
@@ -143,6 +136,11 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         return getInstance().getUnionBuilder(iface);
     }
 
+    public String getTypeName(Class<?> objectClass) {
+        GraphQLName name = objectClass.getAnnotation(GraphQLName.class);
+        return (name == null ? objectClass.getSimpleName() : name.value());
+    }
+
     @Override
     public GraphQLInterfaceType.Builder getIfaceBuilder(Class<?> iface) throws GraphQLAnnotationsException,
             IllegalArgumentException {
@@ -151,8 +149,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         }
         GraphQLInterfaceType.Builder builder = newInterface();
 
-        GraphQLName name = iface.getAnnotation(GraphQLName.class);
-        builder.name(name == null ? iface.getSimpleName() : name.value());
+        builder.name(getTypeName(iface));
         GraphQLDescription description = iface.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());
@@ -274,8 +271,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
     @Override
     public GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws GraphQLAnnotationsException {
         GraphQLObjectType.Builder builder = newObject();
-        GraphQLName name = object.getAnnotation(GraphQLName.class);
-        builder.name(name == null ? object.getSimpleName() : name.value());
+        builder.name(getTypeName(object));
         GraphQLDescription description = object.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());
@@ -635,6 +631,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         getInstance().registerType(typeFunction);
     }
 
+    public Map<String, graphql.schema.GraphQLType> getTypeRegistry() {
+        return typeRegistry;
+    }
 
     private static class ConnectionDataFetcher implements DataFetcher {
         private final Class<? extends Connection> connection;

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -1,7 +1,20 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import graphql.ExecutionResult;
-import graphql.ExecutionResultImpl;
 import graphql.GraphQL;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -31,9 +31,12 @@ public class GraphQLFragmentTest {
 
     static Map<String, GraphQLObjectType> registry;
 
+    /**
+     * Test a query which returns a list (RootObject.items) of two different classes (MyObject + MyObject2) which implement the same interface (MyInterface).
+     */
     @Test
-    public void test() throws Exception {
-
+    public void testInterfaceInlineFragment() throws Exception {
+        // Given
         registry = new HashMap<>();
 
         GraphQLInterfaceType iface = (GraphQLInterfaceType) GraphQLAnnotations.iface(MyInterface.class);
@@ -54,9 +57,11 @@ public class GraphQLFragmentTest {
 
         GraphQL graphQL2 = new GraphQL(schema);
 
+        // When
         ExecutionResult graphQLResult = graphQL2.execute("{items { ... on MyObject {a, my {b}} ... on MyObject2 {a, b}  }}", new RootObject());
         Set resultMap = ((Map) graphQLResult.getData()).entrySet();
 
+        // Then
         assertEquals(graphQLResult.getErrors().size(), 0);
         assertEquals(resultMap.size(), 1);
     }

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -1,0 +1,101 @@
+package graphql.annotations;
+
+import graphql.ExecutionResult;
+import graphql.ExecutionResultImpl;
+import graphql.GraphQL;
+import graphql.schema.GraphQLInterfaceType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.TypeResolver;
+import org.testng.annotations.Test;
+
+import java.util.*;
+
+import static org.testng.AssertJUnit.assertEquals;
+
+
+public class GraphQLFragmentTest {
+
+    static Map<String, GraphQLObjectType> registry;
+
+    @Test
+    public void test() throws Exception {
+
+        registry = new HashMap<>();
+
+        GraphQLInterfaceType iface = (GraphQLInterfaceType) GraphQLAnnotations.iface(MyInterface.class);
+
+        GraphQLObjectType rootType = GraphQLAnnotations.object(RootObject.class);
+
+        GraphQLObjectType objectType2 = GraphQLAnnotations.object(MyObject2.class);
+
+        registry.put("MyObject2", objectType2);
+
+        GraphQLObjectType objectType = GraphQLAnnotations.object(MyObject.class);
+
+        registry.put("MyObject", objectType);
+
+        GraphQLSchema schema = GraphQLSchema.newSchema()
+                .query(rootType)
+                .build(new HashSet(Arrays.asList(iface, rootType, objectType, objectType2)));
+
+        GraphQL graphQL2 = new GraphQL(schema);
+
+        ExecutionResult graphQLResult = graphQL2.execute("{items { ... on MyObject {a, my {b}} ... on MyObject2 {a, b}  }}", new RootObject());
+        Set resultMap = ((Map) graphQLResult.getData()).entrySet();
+
+        assertEquals(graphQLResult.getErrors().size(), 0);
+        assertEquals(resultMap.size(), 1);
+    }
+
+    public static class RootObject {
+        @GraphQLField
+        public List<MyInterface> getItems() {
+            return Arrays.asList(new MyObject(), new MyObject2());
+        }
+    }
+
+    public static class MyObject implements MyInterface {
+        public String getA() {
+            return "a1";
+        }
+
+        public String getB() {
+            return "b1";
+        }
+
+        @GraphQLField
+        public MyObject2 getMy() {
+            return new MyObject2();
+        }
+    }
+
+    public static class MyObject2 implements MyInterface {
+        public String getA() {
+            return "a2";
+        }
+
+        public String getB() {
+            return "b2";
+        }
+    }
+
+    @GraphQLTypeResolver(value = MyTypeResolver.class)
+    public static interface MyInterface {
+        @GraphQLField
+        public String getA();
+
+        @GraphQLField
+        public String getB();
+    }
+
+    public static class MyTypeResolver implements TypeResolver {
+
+        @Override
+        public GraphQLObjectType getType(Object object) {
+            return registry.get(object.getClass().getSimpleName());
+        }
+    }
+
+
+}


### PR DESCRIPTION
I've created a fix for this issue https://github.com/graphql-java/graphql-java-annotations/issues/62

I introduced a global typeRegistry for GraphQLType objects.
This registry is asked before creating new instances.

