### PR TITLE
[WIP] Support for complex input type annotated with GraphQLModifiedType

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -519,6 +519,10 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                     if (graphQLType instanceof GraphQLObjectType) {
                         GraphQLInputObjectType inputObject = getInputObject((GraphQLObjectType) graphQLType);
                         graphQLType = inputObject;
+                    } else if (graphQLType instanceof GraphQLNonNull &&
+                            ((GraphQLNonNull) graphQLType).getWrappedType() instanceof GraphQLObjectType) {
+                        GraphQLInputObjectType inputObject = getInputObject((GraphQLObjectType) ((GraphQLNonNull) graphQLType).getWrappedType());
+                        graphQLType = inputObject;
                     }
                     return getArgument(parameter, graphQLType);
                 }).collect(Collectors.toList());

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -26,6 +26,7 @@ import graphql.schema.GraphQLInputType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLNonNull;
+import graphql.schema.GraphQLModifiedType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLUnionType;
@@ -519,9 +520,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                     if (graphQLType instanceof GraphQLObjectType) {
                         GraphQLInputObjectType inputObject = getInputObject((GraphQLObjectType) graphQLType);
                         graphQLType = inputObject;
-                    } else if (graphQLType instanceof GraphQLNonNull &&
-                            ((GraphQLNonNull) graphQLType).getWrappedType() instanceof GraphQLObjectType) {
-                        GraphQLInputObjectType inputObject = getInputObject((GraphQLObjectType) ((GraphQLNonNull) graphQLType).getWrappedType());
+                    } else if (graphQLType instanceof GraphQLModifiedType &&
+                            ((GraphQLModifiedType) graphQLType).getWrappedType() instanceof GraphQLObjectType) {
+                        GraphQLInputObjectType inputObject = getInputObject((GraphQLObjectType) ((GraphQLModifiedType) graphQLType).getWrappedType());
                         graphQLType = inputObject;
                     }
                     return getArgument(parameter, graphQLType);

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -76,7 +76,7 @@ class MethodDataFetcher implements DataFetcher {
                 continue;
             }
             graphql.schema.GraphQLType graphQLType = typeFunction.apply(paramType, p.getAnnotatedType());
-            if (graphQLType instanceof GraphQLObjectType) {
+            if (graphQLType instanceof GraphQLObjectType || graphQLType instanceof graphql.schema.GraphQLNonNull) {
                 Constructor<?> constructor = constructor(paramType, HashMap.class);
                 result.add(constructNewInstance(constructor, envArgs.next()));
 

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -16,6 +16,7 @@ package graphql.annotations;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLModifiedType;
 import graphql.schema.GraphQLObjectType;
 
 import java.lang.reflect.Constructor;
@@ -76,7 +77,7 @@ class MethodDataFetcher implements DataFetcher {
                 continue;
             }
             graphql.schema.GraphQLType graphQLType = typeFunction.apply(paramType, p.getAnnotatedType());
-            if (graphQLType instanceof GraphQLObjectType || graphQLType instanceof graphql.schema.GraphQLNonNull) {
+            if (graphQLType instanceof GraphQLObjectType || graphQLType instanceof GraphQLModifiedType) {
                 Constructor<?> constructor = constructor(paramType, HashMap.class);
                 result.add(constructNewInstance(constructor, envArgs.next()));
 

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -549,7 +549,7 @@ public class GraphQLObjectTest {
 
     private static class TestObjectInput {
         @GraphQLField
-        public String test(int other, TestInputArgument arg) {
+        public String test(int other, @GraphQLNonNull TestInputArgument arg) {
             return arg.a;
         }
     }


### PR DESCRIPTION
Fixes issue #78 where a complex input type would fail to be resolved if such input is annotated with `@GraphQLModifiedType`

The change boils down to inspecting the `GraphQLModifiedType`'s wrapped type