### PR TITLE
Add support for args for DataFetcher declared in method 

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 27 10:18:00 ICT 2016
+#Tue Jun 06 09:11:54 NZST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip

--- a/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
@@ -16,7 +16,11 @@ package graphql.annotations;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.schema.*;
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.PropertyDataFetcher;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;

--- a/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
@@ -118,9 +118,9 @@ public class GraphQLDataFetcherTest {
         @GraphQLDataFetcher(value = SampleMultiArgDataFetcher.class, firstArgIsTargetName = true, args = {"true"})
         public Boolean isBad() { return false; } // Defaults to FieldDataFetcher
 
-        }
+    }
 
-        public static class SampleDataFetcher implements DataFetcher {
+    public static class SampleDataFetcher implements DataFetcher {
         @Override
         public Object get(final DataFetchingEnvironment environment) {
             return new Sample(); // Notice that it return a Sample, not a TestSample
@@ -155,7 +155,7 @@ public class GraphQLDataFetcherTest {
         @Override
         public Object get(DataFetchingEnvironment environment) {
             final Object result = super.get(environment);
-            if ( flip ) {
+            if (flip) {
                 return !(Boolean)result;
             } else {
                 return result;


### PR DESCRIPTION
This PR fixes https://github.com/graphql-java/graphql-java-annotations/issues/85

It adds the missing support for passing arguments to DataFetchers declared in GraphQLFields that are declared as method. This extends the existing functionality that was only covered for fields.