### PR TITLE
#84 - moves  to graphql 3.0.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -62,7 +62,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
-    compile 'com.graphql-java:graphql-java:2.2.0'
+    compile 'com.graphql-java:graphql-java:3.0.0'
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Oct 27 10:18:00 ICT 2016
+#Tue Jun 06 14:52:40 AEST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.1-all.zip

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -45,6 +45,7 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static graphql.annotations.util.NamingKit.toGraphqlName;
 import static graphql.schema.GraphQLEnumType.newEnum;
 
 @Component(scope = ServiceScope.SINGLETON, property = "type=default")
@@ -226,7 +227,7 @@ public class DefaultTypeFunction implements TypeFunction {
         @Override
         public GraphQLType apply(Class<?> aClass, AnnotatedType annotatedType) {
             GraphQLName name = aClass.getAnnotation(GraphQLName.class);
-            String typeName = name == null ? aClass.getSimpleName() : name.value();
+            String typeName = toGraphqlName(name == null ? aClass.getSimpleName() : name.value());
 
             if (types.containsKey(typeName)) {
                 return types.get(typeName);
@@ -282,7 +283,7 @@ public class DefaultTypeFunction implements TypeFunction {
         @Override
         public GraphQLType apply(Class<?> aClass, AnnotatedType annotatedType) {
             GraphQLName name = aClass.getAnnotation(GraphQLName.class);
-            String typeName = name == null ? aClass.getName() : name.value();
+            String typeName = toGraphqlName(name == null ? aClass.getName() : name.value());
             if (types.containsKey(typeName)) {
                 return types.get(typeName);
             } else if (processing.containsKey(typeName)) {
@@ -293,7 +294,7 @@ public class DefaultTypeFunction implements TypeFunction {
                 if (aClass.isInterface()) {
                     type = annotationsProcessor.getInterface(aClass);
                 } else {
-                    type = annotationsProcessor.getObject(aClass);
+                    type = annotationsProcessor.getObjectOrRef(aClass);
                 }
                 types.put(typeName, type);
                 processing.remove(typeName);

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -17,6 +17,7 @@ package graphql.annotations;
 import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLUnionType;
 
 public interface GraphQLAnnotationsProcessor {
@@ -70,6 +71,18 @@ public interface GraphQLAnnotationsProcessor {
     GraphQLObjectType getObject(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
+     * This will examine the object class and return a {@link GraphQLOutputType} representation
+     * which may be a {@link GraphQLObjectType} or a {@link graphql.schema.GraphQLTypeReference}
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLOutputType} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLOutputType getObjectOrRef(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
      * This will examine the object class and return a {@link GraphQLObjectType.Builder} ready for further definition
      *
      * @param object the object class to examine
@@ -84,8 +97,9 @@ public interface GraphQLAnnotationsProcessor {
      * This will turn a {@link GraphQLObjectType} into a corresponding {@link GraphQLInputObjectType}
      *
      * @param graphQLType the graphql object type
+     * @param newNamePrefix since graphql types MUST be unique, this prefix will be applied to the new input types
      *
      * @return a {@link GraphQLInputObjectType}
      */
-    GraphQLInputObjectType getInputObject(GraphQLObjectType graphQLType);
+    GraphQLInputObjectType getInputObject(GraphQLObjectType graphQLType, String newNamePrefix);
 }

--- a/src/main/java/graphql/annotations/ListConnection.java
+++ b/src/main/java/graphql/annotations/ListConnection.java
@@ -18,8 +18,8 @@ import graphql.relay.SimpleListConnection;
 
 import java.util.List;
 
-public class ListConnection extends SimpleListConnection implements Connection {
-    public ListConnection(List<?> data) {
+public class ListConnection<T> extends SimpleListConnection<T> {
+    public ListConnection(List<T> data) {
         super(data);
     }
 }

--- a/src/main/java/graphql/annotations/StreamConnection.java
+++ b/src/main/java/graphql/annotations/StreamConnection.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,8 +14,12 @@
  */
 package graphql.annotations;
 
-import graphql.relay.Base64;
+import graphql.annotations.util.Base64;
 import graphql.relay.ConnectionCursor;
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultConnectionCursor;
+import graphql.relay.DefaultEdge;
+import graphql.relay.DefaultPageInfo;
 import graphql.relay.Edge;
 import graphql.relay.PageInfo;
 import graphql.schema.DataFetcher;
@@ -26,33 +30,38 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static graphql.annotations.util.RelayKit.EMPTY_CONNECTION;
+
 public class StreamConnection implements DataFetcher, Connection {
 
     private final Stream<?> stream;
     private static final String DUMMY_CURSOR_PREFIX = "stream-cursor";
-    
+
     public StreamConnection(Stream<?> stream) {
         this.stream = stream;
     }
 
-    private Stream<Edge> buildEdges() {
+    private Stream<Edge<Object>> buildEdges() {
         AtomicInteger ix = new AtomicInteger();
-        return stream.map(obj -> new Edge(obj, new ConnectionCursor(createCursor(ix.incrementAndGet()))));
+        return stream.map(obj -> {
+            ConnectionCursor connectionCursor = new DefaultConnectionCursor(createCursor(ix.incrementAndGet()));
+            return new DefaultEdge<>(obj, connectionCursor);
+        });
     }
 
 
     @Override
     public Object get(DataFetchingEnvironment environment) {
 
-        int afterOffset = getOffsetFromCursor(environment.<String>getArgument("after"), 0);
-        int beforeOffset = getOffsetFromCursor(environment.<String>getArgument("before"), Integer.MAX_VALUE);
+        int afterOffset = getOffsetFromCursor(environment.getArgument("after"), 0);
+        int beforeOffset = getOffsetFromCursor(environment.getArgument("before"), Integer.MAX_VALUE);
 
-        Stream<Edge> edgesStream = buildEdges().skip(afterOffset).limit(beforeOffset - afterOffset);
+        Stream<Edge<Object>> edgesStream = buildEdges().skip(afterOffset).limit(beforeOffset - afterOffset);
 
-        List<Edge> edges = edgesStream.collect(Collectors.toList());
+        List<Edge<Object>> edges = edgesStream.collect(Collectors.toList());
 
         if (edges.size() == 0) {
-            return emptyConnection();
+            return EMPTY_CONNECTION;
         }
 
         Integer first = environment.<Integer>getArgument("first");
@@ -69,38 +78,22 @@ public class StreamConnection implements DataFetcher, Connection {
         }
 
         if (edges.size() == 0) {
-            return emptyConnection();
+            return EMPTY_CONNECTION;
         }
 
         Edge firstEdge = edges.get(0);
         Edge lastEdge = edges.get(edges.size() - 1);
+        boolean hasPrevious = !firstEdge.getCursor().equals(firstPresliceCursor);
+        boolean hasNext = !lastEdge.getCursor().equals(lastPresliceCursor);
 
-        PageInfo pageInfo = new PageInfo();
-        pageInfo.setStartCursor(firstEdge.getCursor());
-        pageInfo.setEndCursor(lastEdge.getCursor());
-        pageInfo.setHasPreviousPage(!firstEdge.getCursor().equals(firstPresliceCursor));
-        pageInfo.setHasNextPage(!lastEdge.getCursor().equals(lastPresliceCursor));
+        PageInfo pageInfo = new DefaultPageInfo(
+                firstEdge.getCursor(),
+                lastEdge.getCursor(),
+                hasPrevious, hasNext
+        );
 
-        graphql.relay.Connection connection = new graphql.relay.Connection();
-        connection.setEdges(edges);
-        connection.setPageInfo(pageInfo);
-
-        return connection;
+        return new DefaultConnection<>(edges, pageInfo);
     }
-
-    private graphql.relay.Connection emptyConnection() {
-        graphql.relay.Connection connection = new graphql.relay.Connection();
-        connection.setPageInfo(new PageInfo());
-        return connection;
-    }
-
-
-//    public ConnectionCursor cursorForObjectInConnection(Object object) {
-//        int index = data.indexOf(object);
-//        String cursor = createCursor(index);
-//        return new ConnectionCursor(cursor);
-//    }
-
 
     private int getOffsetFromCursor(String cursor, int defaultValue) {
         if (cursor == null) return defaultValue;
@@ -109,7 +102,7 @@ public class StreamConnection implements DataFetcher, Connection {
     }
 
     private String createCursor(int offset) {
-        String string = Base64.toBase64(DUMMY_CURSOR_PREFIX + Integer.toString(offset));
-        return string;
+        return Base64.toBase64(DUMMY_CURSOR_PREFIX + Integer.toString(offset));
     }
+
 }

--- a/src/main/java/graphql/annotations/util/Base64.java
+++ b/src/main/java/graphql/annotations/util/Base64.java
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.util;
+
+import javax.xml.bind.DatatypeConverter;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.Charset;
+
+public class Base64 {
+
+    private Base64() {
+    }
+
+    public static String toBase64(String string) {
+        try {
+            return DatatypeConverter.printBase64Binary(string.getBytes("utf-8"));
+        } catch (UnsupportedEncodingException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String fromBase64(String string) {
+        return new String(DatatypeConverter.parseBase64Binary(string), Charset.forName("UTF-8"));
+    }
+}

--- a/src/main/java/graphql/annotations/util/NamingKit.java
+++ b/src/main/java/graphql/annotations/util/NamingKit.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.util;
+
+import java.util.regex.Pattern;
+
+public class NamingKit {
+
+    private final static Pattern VALID_NAME = Pattern.compile("[_A-Za-z][_0-9A-Za-z]*");
+    private final static Pattern VALID_START = Pattern.compile("[_A-Za-z]");
+    private final static Pattern VALID_CHAR = Pattern.compile("[_0-9A-Za-z]");
+
+    /**
+     * Graphql 3.x has valid names of [_A-Za-z][_0-9A-Za-z]* and hence Java generated names like Class$Inner wont work
+     * so we make a unique name from it
+     *
+     * @param name the name to ensure
+     *
+     * @return
+     */
+    public static String toGraphqlName(String name) {
+        if (VALID_NAME.matcher(name).matches()) {
+            return name;
+        }
+        StringBuilder sb = new StringBuilder();
+        for (int i = 0; i < name.length(); i++) {
+            char c = name.charAt(i);
+            String sChar = new String(new char[]{c});
+            // check start character differently
+            if (i == 0) {
+                if (!VALID_START.matcher(sChar).matches()) {
+                    replace(sb, c);
+                } else {
+                    sb.append(c);
+                }
+            } else {
+                if (!VALID_CHAR.matcher(sChar).matches()) {
+                    replace(sb, c);
+                } else {
+                    sb.append(c);
+                }
+            }
+        }
+        return sb.toString();
+    }
+
+    private static void replace(StringBuilder sb, char c) {
+        // the most common in Java class land is . and $ so for readability we make them
+        // just _
+        if (c == '.' || c == '$') {
+            sb.append('_');
+        } else {
+            sb.append("_");
+            Integer iChar = (int) c;
+            sb.append(iChar.toString());
+            sb.append("_");
+        }
+    }
+}

--- a/src/main/java/graphql/annotations/util/RelayKit.java
+++ b/src/main/java/graphql/annotations/util/RelayKit.java
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.util;
+
+import graphql.relay.DefaultConnection;
+import graphql.relay.DefaultPageInfo;
+import graphql.relay.PageInfo;
+
+import java.util.Collections;
+
+public class RelayKit {
+    /**
+     * An empty page info
+     */
+    public static final PageInfo EMPTY_PAGE_INFO = new DefaultPageInfo(null, null, false, false);
+
+    /**
+     * An empty connection
+     */
+    public static final graphql.relay.Connection<Object> EMPTY_CONNECTION = new DefaultConnection<>(Collections.emptyList(), EMPTY_PAGE_INFO);
+}

--- a/src/main/java/graphql/execution/TypeInfoWorkaround.java
+++ b/src/main/java/graphql/execution/TypeInfoWorkaround.java
@@ -5,16 +5,26 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  */
-package graphql.annotations;
 
-import graphql.schema.DataFetcher;
+package graphql.execution;
 
-public interface Connection<T> extends DataFetcher<T> {
+import graphql.schema.GraphQLType;
+
+/**
+ * Graphql 3.0.0 exposed {@link TypeInfo} but the builder is not public
+ * and hence it cant be used outside its package.  Until this gets fixed
+ * this is the work around
+ */
+public class TypeInfoWorkaround {
+
+    public static TypeInfo newTypeInfo(GraphQLType childType, TypeInfo parentTypeInfo) {
+        return TypeInfo.newTypeInfo().parentInfo(parentTypeInfo).type(childType).build();
+    }
 }

--- a/src/test/java/graphql/annotations/GraphQLBatchedTest.java
+++ b/src/test/java/graphql/annotations/GraphQLBatchedTest.java
@@ -55,7 +55,7 @@ public class GraphQLBatchedTest {
 
         GraphQLObjectType object = GraphQLAnnotations.object(TestBatchedObject.class);
         GraphQLSchema schema = newSchema().query(object).build();
-        GraphQL graphql = new GraphQL(schema, new BatchedExecutionStrategy());
+        GraphQL graphql = GraphQL.newGraphQL(schema).queryExecutionStrategy(new BatchedExecutionStrategy()).build();
         ExecutionResult result = graphql.execute("{ fields { a } }", new TestBatchedObject());
         List errors = result.getErrors();
         for (Object e : errors) {

--- a/src/test/java/graphql/annotations/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLConnectionTest.java
@@ -16,18 +16,17 @@ package graphql.annotations;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.relay.PageInfo;
 import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+import static graphql.annotations.util.RelayKit.EMPTY_CONNECTION;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -62,7 +61,8 @@ public class GraphQLConnectionTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestListField.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestListField(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
         assertTrue(result.getErrors().isEmpty());
 
@@ -83,7 +83,7 @@ public class GraphQLConnectionTest {
         }
 
         @GraphQLField
-        @GraphQLConnection
+        @GraphQLConnection(name = "objStream")
         public Stream<Obj> getObjStream() {
             Obj[] a = new Obj[objs.size()];
             return Stream.of(objs.toArray(a));
@@ -95,7 +95,8 @@ public class GraphQLConnectionTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestConnections.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
@@ -105,7 +106,7 @@ public class GraphQLConnectionTest {
     }
 
     public void testResult(String name, ExecutionResult result) {
-        Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = (Map<String, Map<String, List<Map<String, Map<String, Object>>>>>) result.getData();
+        Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = result.getData();
         List<Map<String, Map<String, Object>>> edges = data.get(name).get("edges");
 
         assertEquals(edges.size(), 1);
@@ -118,7 +119,8 @@ public class GraphQLConnectionTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestConnections.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{ objStream(first: 1) { edges { cursor node { id, val } } } }",
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ objStream(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
@@ -134,11 +136,7 @@ public class GraphQLConnectionTest {
 
         @Override
         public Object get(DataFetchingEnvironment environment) {
-            graphql.relay.Connection connection = new graphql.relay.Connection();
-            connection.setEdges(Collections.emptyList());
-            PageInfo pageInfo = new PageInfo();
-            connection.setPageInfo(pageInfo);
-            return connection;
+            return EMPTY_CONNECTION;
         }
     }
 
@@ -161,7 +159,8 @@ public class GraphQLConnectionTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestCustomConnection.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestCustomConnection(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());

--- a/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -13,8 +13,6 @@
  * See the License for the specific language governing permissions and
  */
 package graphql.annotations;
-
-import java.util.HashMap;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
@@ -25,94 +23,95 @@ import graphql.schema.GraphQLSchema;
 import graphql.schema.PropertyDataFetcher;
 import org.testng.annotations.Test;
 
+import java.util.HashMap;
+
 import static graphql.schema.GraphQLSchema.newSchema;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class GraphQLDataFetcherTest {
 
-  @Test
-  public void shouldUsePreferredConstructor() {
-    // Given
-    final GraphQLObjectType object = GraphQLAnnotations.object(GraphQLDataFetcherTest.TestGraphQLQuery.class);
-    final GraphQLSchema schema = newSchema().query(object).build();
-    final GraphQL graphql = new GraphQL(schema);
+    @Test
+    public void shouldUsePreferredConstructor() {
+        // Given
+        final GraphQLObjectType object = GraphQLAnnotations.object(GraphQLDataFetcherTest.TestGraphQLQuery.class);
+        final GraphQLSchema schema = newSchema().query(object).build();
+        GraphQL graphql = GraphQL.newGraphQL(schema).build();
 
-    // When
-    final ExecutionResult result = graphql.execute("{sample {isGreat isBad}}");
+        // When
+        final ExecutionResult result = graphql.execute("{sample {isGreat isBad}}");
 
-    // Then
-    final HashMap<String, Object> data = (HashMap) result.getData();
-    assertNotNull(data);
-    assertTrue(((HashMap<String,Boolean>)data.get("sample")).get("isGreat"));
-    assertTrue(((HashMap<String,Boolean>)data.get("sample")).get("isBad"));
-  }
-
-  @GraphQLName("Query")
-  public static class TestGraphQLQuery {
-    @GraphQLField
-    @GraphQLDataFetcher(SampleDataFetcher.class)
-    public TestSample sample() { // Note that GraphQL uses TestSample to build the graph
-      return null;
-    }
-  }
-
-  public static class TestSample {
-    @GraphQLField
-    @GraphQLDataFetcher(value = PropertyDataFetcher.class, args = "isGreat")
-    private Boolean isGreat = false; // Defaults to FieldDataFetcher
-
-    @GraphQLField
-    @GraphQLDataFetcher(value = SampleMultiArgDataFetcher.class, firstArgIsTargetName = true, args = {"true"})
-    private Boolean isBad = false; // Defaults to FieldDataFetcher
-
-  }
-
-  public static class SampleDataFetcher implements DataFetcher {
-    @Override
-    public Object get(final DataFetchingEnvironment environment) {
-      return new Sample(); // Notice that it return a Sample, not a TestSample
-    }
-  }
-
-  public static class SampleMultiArgDataFetcher extends PropertyDataFetcher {
-    private boolean flip = false;
-
-    public SampleMultiArgDataFetcher(String target, String flip) {
-      super(target);
-      this.flip = Boolean.valueOf(flip);
+        // Then
+        final HashMap<String, Object> data = (HashMap) result.getData();
+        assertNotNull(data);
+        assertTrue(((HashMap<String, Boolean>) data.get("sample")).get("isGreat"));
+        assertTrue(((HashMap<String, Boolean>) data.get("sample")).get("isBad"));
     }
 
-    @Override
-    public Object get(DataFetchingEnvironment environment) {
-      final Object result = super.get(environment);
-      if ( flip ) {
-        return !(Boolean)result;
-      } else {
-        return result;
-      }
-    }
-  }
-
-  public static class Sample {
-    private Boolean isGreat = true;
-    private Boolean isBad = false;
-
-    public Boolean getIsGreat() {
-      return isGreat;
+    @GraphQLName("Query")
+    public static class TestGraphQLQuery {
+        @GraphQLField
+        @GraphQLDataFetcher(SampleDataFetcher.class)
+        public TestSample sample() { // Note that GraphQL uses TestSample to build the graph
+            return null;
+        }
     }
 
-    public void setIsGreat(final Boolean isGreat) {
-      this.isGreat = isGreat;
+    public static class TestSample {
+        @GraphQLField
+        @GraphQLDataFetcher(value = PropertyDataFetcher.class, args = "isGreat")
+        private Boolean isGreat = false; // Defaults to FieldDataFetcher
+
+        @GraphQLField
+        @GraphQLDataFetcher(value = SampleMultiArgDataFetcher.class, firstArgIsTargetName = true, args = {"true"})
+        private Boolean isBad = false; // Defaults to FieldDataFetcher
+
     }
 
-    public Boolean getIsBad() {
-      return isBad;
+    public static class SampleDataFetcher implements DataFetcher {
+        @Override
+        public Object get(final DataFetchingEnvironment environment) {
+            return new Sample(); // Notice that it return a Sample, not a TestSample
+        }
     }
 
-    public void setIsBad(Boolean bad) {
-      isBad = bad;
+    public static class SampleMultiArgDataFetcher extends PropertyDataFetcher {
+        private boolean flip = false;
+
+        public SampleMultiArgDataFetcher(String target, String flip) {
+            super(target);
+            this.flip = Boolean.valueOf(flip);
+        }
+
+        @Override
+        public Object get(DataFetchingEnvironment environment) {
+            final Object result = super.get(environment);
+            if (flip) {
+                return !(Boolean) result;
+            } else {
+                return result;
+            }
+        }
     }
-  }
+
+    public static class Sample {
+        private Boolean isGreat = true;
+        private Boolean isBad = false;
+
+        public Boolean getIsGreat() {
+            return isGreat;
+        }
+
+        public void setIsGreat(final Boolean isGreat) {
+            this.isGreat = isGreat;
+        }
+
+        public Boolean getIsBad() {
+            return isBad;
+        }
+
+        public void setIsBad(Boolean bad) {
+            isBad = bad;
+        }
+    }
 }

--- a/src/test/java/graphql/annotations/GraphQLEnumTest.java
+++ b/src/test/java/graphql/annotations/GraphQLEnumTest.java
@@ -62,7 +62,7 @@ public class GraphQLEnumTest {
     @Test
     public void test() throws IllegalAccessException, NoSuchMethodException, InstantiationException {
         GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
-        GraphQL graphql = new GraphQL(newSchema().query(queryObject).build());
+        GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
         ExecutionResult result = graphql.execute("{ defaultUser{ name } }");
         assertEquals(result.getData().toString(), "{defaultUser={name=ONE}}");

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -16,13 +16,19 @@ package graphql.annotations;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.TypeResolutionEnvironment;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.TypeResolver;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -53,9 +59,9 @@ public class GraphQLFragmentTest {
 
         GraphQLSchema schema = GraphQLSchema.newSchema()
                 .query(rootType)
-                .build(new HashSet(Arrays.asList(iface, rootType, objectType, objectType2)));
+                .build(new HashSet<>(Arrays.<graphql.schema.GraphQLType>asList(iface, objectType)));
 
-        GraphQL graphQL2 = new GraphQL(schema);
+        GraphQL graphQL2 = GraphQL.newGraphQL(schema).build();
 
         // When
         ExecutionResult graphQLResult = graphQL2.execute("{items { ... on MyObject {a, my {b}} ... on MyObject2 {a, b}  }}", new RootObject());
@@ -110,8 +116,8 @@ public class GraphQLFragmentTest {
     public static class MyTypeResolver implements TypeResolver {
 
         @Override
-        public GraphQLObjectType getType(Object object) {
-            return registry.get(object.getClass().getSimpleName());
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            return registry.get(env.getObject().getClass().getSimpleName());
         }
     }
 

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -221,9 +221,10 @@ public class GraphQLObjectTest {
         GraphQLSchema schema = newSchema().query(object).build();
         GraphQLSchema schemaInherited = newSchema().query(objectInherited).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{field0}", new TestObject());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field0}", new TestObject());
         assertEquals(((Map<String, Object>) result.getData()).get("field0"), "test");
-        result = new GraphQL(schemaInherited).execute("{field1}", new TestObjectInherited());
+        GraphQL graphQL = GraphQL.newGraphQL(schemaInherited).build();
+        result = graphQL.execute("{field1}", new TestObjectInherited());
         assertEquals(((Map<String, Object>) result.getData()).get("field1"), "inherited");
     }
 
@@ -258,7 +259,7 @@ public class GraphQLObjectTest {
 
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{id}", new TestObjectBridgMethod());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{id}", new TestObjectBridgMethod());
         assertEquals(((Map<String, Object>) result.getData()).get("id"), 1L);
     }
 
@@ -407,7 +408,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestDataFetcher.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{field someField}", new TestObject());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field someField}", new TestObject());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("field"), "test");
         assertEquals(((Map<String, String>) result.getData()).get("someField"), "test");
@@ -418,15 +419,15 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObject.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{field0}", new TestObject());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field0}", new TestObject());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("field0"), "test");
 
-        result = new GraphQL(schema).execute("{fieldWithArgs(a: \"test\", b: \"passed\")}", new TestObject());
+        result = GraphQL.newGraphQL(schema).build().execute("{fieldWithArgs(a: \"test\", b: \"passed\")}", new TestObject());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("fieldWithArgs"), "passed");
 
-        result = new GraphQL(schema).execute("{fieldWithArgsAndEnvironment(a: \"test\", b: \"passed\")}", new TestObject());
+        result = GraphQL.newGraphQL(schema).build().execute("{fieldWithArgsAndEnvironment(a: \"test\", b: \"passed\")}", new TestObject());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("fieldWithArgsAndEnvironment"), "test");
 
@@ -437,7 +438,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestField.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{field1}", new TestField());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field1}", new TestField());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("field1"), "test");
     }
@@ -447,7 +448,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(PrivateTestField.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{field1, field2, booleanField}", new PrivateTestField());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field1, field2, booleanField}", new PrivateTestField());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("field1"), "test");
         assertEquals(((Map<String, String>) result.getData()).get("field2"), "test");
@@ -460,7 +461,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObject.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema).execute("{fieldWithArgs(a: \"test\")}", new TestObject());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{fieldWithArgs(a: \"test\")}", new TestObject());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, String>) result.getData()).get("fieldWithArgs"), "default");
     }
@@ -492,18 +493,18 @@ public class GraphQLObjectTest {
         class2.value = "hello";
         class1.value = "bye";
 
-        ExecutionResult result = new GraphQL(schema).execute("{ class2 { value } }", class1);
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{ class2 { value } }", class1);
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> data = (Map<String, Object>) result.getData();
         assertEquals(((Map<String, Object>) data.get("class2")).get("value"), "hello");
 
-        result = new GraphQL(schema).execute("{ class2 { class1 { value } } }", class1);
+        result = GraphQL.newGraphQL(schema).build().execute("{ class2 { class1 { value } } }", class1);
         assertTrue(result.getErrors().isEmpty());
         data = (Map<String, Object>) result.getData();
         Map<String, Object> k1 = (Map<String, Object>) ((Map<String, Object>) data.get("class2")).get("class1");
         assertEquals(k1.get("value"), "bye");
 
-        result = new GraphQL(schema).execute("{ class2 { class1 { class2 { value } } } }", class1);
+        result = GraphQL.newGraphQL(schema).build().execute("{ class2 { class1 { class2 { value } } } }", class1);
         assertTrue(result.getErrors().isEmpty());
     }
 
@@ -562,7 +563,7 @@ public class GraphQLObjectTest {
         assertEquals(argument.getName(), "arg");
 
         GraphQLSchema schema = newSchema().query(object).build();
-        ExecutionResult result = new GraphQL(schema).execute("{ test(arg: { a:\"ok\", b:2 }, other:0) }", new TestObjectInput());
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{ test(arg: { a:\"ok\", b:2 }, other:0) }", new TestObjectInput());
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> v = (Map<String, Object>) result.getData();
         assertEquals(v.get("test"), "ok");
@@ -571,7 +572,7 @@ public class GraphQLObjectTest {
     @Test
     public void inputObject() {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObjectInput.class);
-        GraphQLInputObjectType inputObjectType = GraphQLAnnotations.inputObject(object);
+        GraphQLInputObjectType inputObjectType = GraphQLAnnotations.inputObject(object, "input");
         assertEquals(inputObjectType.getFields().size(), object.getFieldDefinitions().size());
     }
 
@@ -615,7 +616,8 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(OptionalTest.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
-        ExecutionResult result = new GraphQL(schema, new EnhancedExecutionStrategy()).execute("{empty, nonempty}", new OptionalTest());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
+        ExecutionResult result = graphQL.execute("{empty, nonempty}", new OptionalTest());
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> v = (Map<String, Object>) result.getData();
         assertNull(v.get("empty"));
@@ -625,7 +627,7 @@ public class GraphQLObjectTest {
     @Test
     public void optionalInput() {
         GraphQLObjectType object = GraphQLAnnotations.object(OptionalTest.class);
-        GraphQLInputObjectType inputObject = GraphQLAnnotations.inputObject(object);
+        GraphQLInputObjectType inputObject = GraphQLAnnotations.inputObject(object, "input");
         GraphQLObjectType mutation = GraphQLObjectType.newObject().name("mut").field(newFieldDefinition().name("test").type(object).
                 argument(GraphQLArgument.newArgument().type(inputObject).name("input").build()).dataFetcher(environment -> {
             Map<String, String> input = environment.getArgument("input");
@@ -633,7 +635,8 @@ public class GraphQLObjectTest {
         }).build()).build();
         GraphQLSchema schema = newSchema().query(object).mutation(mutation).build();
 
-        ExecutionResult result = new GraphQL(schema, new EnhancedExecutionStrategy()).execute("mutation {test(input: {empty: \"test\"}) { empty nonempty } }", new OptionalTest());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
+        ExecutionResult result = graphQL.execute("mutation {test(input: {empty: \"test\"}) { empty nonempty } }", new OptionalTest());
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> v = (Map<String, Object>) ((Map<String, Object>) result.getData()).get("test");
         assertEquals(v.get("empty"), "test");
@@ -663,8 +666,9 @@ public class GraphQLObjectTest {
     public void queryEnum() {
         GraphQLObjectType object = GraphQLAnnotations.object(EnumTest.class);
         GraphQLSchema schema = newSchema().query(object).build();
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
-        ExecutionResult result = new GraphQL(schema, new EnhancedExecutionStrategy()).execute("{e}", new EnumTest(EnumTest.E.B));
+        ExecutionResult result = graphQL.execute("{e}", new EnumTest(EnumTest.E.B));
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> v = (Map<String, Object>) result.getData();
         assertEquals(v.get("e"), "B");

--- a/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
+++ b/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -63,7 +63,7 @@ public class GraphQLSimpleSchemaTest {
     @Test
     public void detachedCall() {
         GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
-        GraphQL graphql = new GraphQL(newSchema().query(queryObject).build());
+        GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
         ExecutionResult result = graphql.execute("{ defaultUser{ name } }");
         String actual = result.getData().toString();
@@ -73,7 +73,7 @@ public class GraphQLSimpleSchemaTest {
     @Test
     public void staticCall() {
         GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
-        GraphQL graphql = new GraphQL(newSchema().query(queryObject).build());
+        GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
         ExecutionResult result = graphql.execute("{ defaultUser2{ name } }");
         String actual = result.getData().toString();

--- a/src/test/java/graphql/annotations/MethodDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/MethodDataFetcherTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -14,26 +14,26 @@
  */
 package graphql.annotations;
 
-import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
-import static org.testng.Assert.*;
-
 public class MethodDataFetcherTest {
 
-    public class TestException extends Exception {};
+    public class TestException extends Exception {
+    }
 
     public String method() throws TestException {
         throw new TestException();
     }
+
     @Test(expectedExceptions = RuntimeException.class)
     public void exceptionRethrowing() {
         try {
             MethodDataFetcher methodDataFetcher = new MethodDataFetcher(getClass().getMethod("method"));
-            methodDataFetcher.get(new DataFetchingEnvironment(this, new HashMap<>(), null, new ArrayList<>(), null, null, null));
+            methodDataFetcher.get(new DataFetchingEnvironmentImpl(this, new HashMap<>(), null, new ArrayList<>(), null, null, null, null, null, null));
         } catch (NoSuchMethodException e) {
             e.printStackTrace();
         }

--- a/src/test/java/graphql/annotations/RelayTest.java
+++ b/src/test/java/graphql/annotations/RelayTest.java
@@ -16,6 +16,7 @@ package graphql.annotations;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
+import graphql.TypeResolutionEnvironment;
 import graphql.schema.*;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
@@ -32,7 +33,7 @@ public class RelayTest {
     public static class ResultTypeResolver implements TypeResolver {
 
         @Override
-        public GraphQLObjectType getType(Object object) {
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
             return GraphQLAnnotations.object(Result.class);
         }
     }
@@ -105,7 +106,7 @@ public class RelayTest {
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
-        GraphQL graphQL = new GraphQL(schema, new EnhancedExecutionStrategy());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
         ExecutionResult result = graphQL.execute("mutation { doSomething(input: {clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
 
@@ -127,7 +128,7 @@ public class RelayTest {
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
-        GraphQL graphQL = new GraphQL(schema, new EnhancedExecutionStrategy());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
         ExecutionResult result = graphQL.execute("mutation { doSomethingI(input: {clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
 
@@ -166,7 +167,7 @@ public class RelayTest {
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
-        GraphQL graphQL = new GraphQL(schema, new EnhancedExecutionStrategy());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
         ExecutionResult result = graphQL.execute("mutation { doSomethingElse(input: {a: 0, b: 1, clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
 
@@ -203,7 +204,7 @@ public class RelayTest {
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
-        GraphQL graphQL = new GraphQL(schema, new EnhancedExecutionStrategy());
+        GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
         Map<String, Object> variables = new HashMap<>();
         Map<String, Object> inputVariables = new HashMap<>();

--- a/src/test/java/graphql/annotations/util/NamingKitTest.java
+++ b/src/test/java/graphql/annotations/util/NamingKitTest.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.util;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class NamingKitTest {
+
+    @Test
+    public void testNameReplacement() throws Exception {
+
+        String result;
+
+        result = NamingKit.toGraphqlName("valid_Name_123");
+        assertEquals(result, "valid_Name_123");
+
+        result = NamingKit.toGraphqlName("Valid_Name_123");
+        assertEquals(result, "Valid_Name_123");
+
+        result = NamingKit.toGraphqlName("replaced$Name_123");
+        assertEquals(result, "replaced_Name_123");
+
+        result = NamingKit.toGraphqlName("com.name.replaced$Name_123");
+        assertEquals(result, "com_name_replaced_Name_123");
+
+        // start chara must be a-zA-Z
+        result = NamingKit.toGraphqlName("1_invalidStart");
+        assertEquals(result, "_49__invalidStart");
+
+        result = NamingKit.toGraphqlName("$_invalidStart");
+        assertEquals(result, "__invalidStart");
+
+    }
+}


### PR DESCRIPTION
This moves this library to graphql 3.x

The main changes is that types MUST be unique singletons and the names of types must be `[_A-Za-z][_0-9A-Za-z]*`