### PR TITLE
Allows to extend GraphQL objects created with annotations

### DIFF
--- a/src/main/java/graphql/annotations/ExtensionDataFetcherWrapper.java
+++ b/src/main/java/graphql/annotations/ExtensionDataFetcherWrapper.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.DataFetchingEnvironmentImpl;
+
+import java.util.Map;
+
+import static graphql.annotations.ReflectionKit.newInstance;
+
+public class ExtensionDataFetcherWrapper implements DataFetcher {
+
+    private final Class declaringClass;
+    private final DataFetcher dataFetcher;
+
+    public ExtensionDataFetcherWrapper(Class declaringClass, DataFetcher dataFetcher) {
+        this.declaringClass = declaringClass;
+        this.dataFetcher = dataFetcher;
+    }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        Object source = environment.getSource();
+        if (source != null && (!declaringClass.isInstance(source)) && !(source instanceof Map)) {
+            environment = new DataFetchingEnvironmentImpl(newInstance(declaringClass, source), environment.getArguments(),
+                    environment.getContext(), environment.getFields(), environment.getFieldType(), environment.getParentType(),
+                    environment.getGraphQLSchema(), environment.getFragmentsByName(), environment.getExecutionId(), environment.getSelectionSet());
+        }
+
+        return dataFetcher.get(environment);
+    }
+
+}

--- a/src/main/java/graphql/annotations/ExtensionDataFetcherWrapper.java
+++ b/src/main/java/graphql/annotations/ExtensionDataFetcherWrapper.java
@@ -22,19 +22,19 @@ import java.util.Map;
 
 import static graphql.annotations.ReflectionKit.newInstance;
 
-public class ExtensionDataFetcherWrapper implements DataFetcher {
+public class ExtensionDataFetcherWrapper<T> implements DataFetcher<T>{
 
     private final Class declaringClass;
-    private final DataFetcher dataFetcher;
+    private final DataFetcher<T> dataFetcher;
 
-    public ExtensionDataFetcherWrapper(Class declaringClass, DataFetcher dataFetcher) {
+    public ExtensionDataFetcherWrapper(Class declaringClass, DataFetcher<T> dataFetcher) {
         this.declaringClass = declaringClass;
         this.dataFetcher = dataFetcher;
     }
 
     @SuppressWarnings("unchecked")
     @Override
-    public Object get(DataFetchingEnvironment environment) {
+    public T get(DataFetchingEnvironment environment) {
         Object source = environment.getSource();
         if (source != null && (!declaringClass.isInstance(source)) && !(source instanceof Map)) {
             environment = new DataFetchingEnvironmentImpl(newInstance(declaringClass, source), environment.getArguments(),

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -332,11 +332,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                         continue;
                     }
                     if (breadthFirstSearch(method)) {
-                        GraphQLFieldDefinition field = getField(method);
-                        if (field.getDataFetcher() instanceof MethodDataFetcher) {
-                            ((MethodDataFetcher) field.getDataFetcher()).setExtension(true);
-                        }
-                        fields.add(field);
+                        fields.add(getField(method));
                     }
                 }
                 for (Field field : getAllFields(aClass).values()) {
@@ -347,7 +343,6 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                         fields.add(getField(field));
                     }
                 }
-
             }
         }
         return fields;
@@ -439,16 +434,16 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
             if (outputType == GraphQLBoolean || (outputType instanceof GraphQLNonNull && ((GraphQLNonNull) outputType).getWrappedType() == GraphQLBoolean)) {
                 if (checkIfPrefixGetterExists(field.getDeclaringClass(), "is", field.getName()) ||
                         checkIfPrefixGetterExists(field.getDeclaringClass(), "get", field.getName())) {
-                    actualDataFetcher = new PropertyDataFetcher(field.getName());
+                    actualDataFetcher = new ExtensionDataFetcherWrapper(field.getDeclaringClass(), new PropertyDataFetcher(field.getName()));
                 }
             } else if (checkIfPrefixGetterExists(field.getDeclaringClass(), "get", field.getName())) {
-                actualDataFetcher = new PropertyDataFetcher(field.getName());
+                actualDataFetcher = new ExtensionDataFetcherWrapper(field.getDeclaringClass(), new PropertyDataFetcher(field.getName()));
             } else if (hasFluentGetter) {
                 actualDataFetcher = new MethodDataFetcher(fluentMethod, typeFunction);
             }
 
             if (actualDataFetcher == null) {
-                actualDataFetcher = new FieldDataFetcher(field.getName());
+                actualDataFetcher = new ExtensionDataFetcherWrapper(field.getDeclaringClass(), new FieldDataFetcher(field.getName()));
             }
         }
 

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -339,6 +339,15 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                         fields.add(field);
                     }
                 }
+                for (Field field : getAllFields(aClass).values()) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        continue;
+                    }
+                    if (parentalSearch(field)) {
+                        fields.add(getField(field));
+                    }
+                }
+
             }
         }
         return fields;

--- a/src/main/java/graphql/annotations/GraphQLTypeExtension.java
+++ b/src/main/java/graphql/annotations/GraphQLTypeExtension.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLTypeExtension {
+    Class<?> value();
+}

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -35,7 +35,6 @@ import static graphql.annotations.ReflectionKit.newInstance;
 class MethodDataFetcher implements DataFetcher {
     private final Method method;
     private final TypeFunction typeFunction;
-    private boolean extension = false;
 
     public MethodDataFetcher(Method method) {
         this(method, new DefaultTypeFunction());
@@ -55,7 +54,7 @@ class MethodDataFetcher implements DataFetcher {
                 obj = null;
             } else if (method.getAnnotation(GraphQLInvokeDetached.class) != null) {
                 obj = newInstance(method.getDeclaringClass());
-            } else if (extension) {
+            } else if (!method.getDeclaringClass().isInstance(environment.getSource())) {
                 obj = newInstance(method.getDeclaringClass(), environment.getSource());
             } else {
                 obj = environment.getSource();
@@ -88,9 +87,5 @@ class MethodDataFetcher implements DataFetcher {
             }
         }
         return result.toArray();
-    }
-
-    public void setExtension(boolean extension) {
-        this.extension = extension;
     }
 }

--- a/src/main/java/graphql/annotations/ReflectionKit.java
+++ b/src/main/java/graphql/annotations/ReflectionKit.java
@@ -47,4 +47,16 @@ class ReflectionKit {
         }
     }
 
+    static <T> T newInstance(Class<T> clazz, Object parameter) {
+        if (parameter != null) {
+            for (Constructor<T> constructor : (Constructor<T>[]) clazz.getConstructors()) {
+                if (constructor.getParameterCount() == 1 && constructor.getParameters()[0].getType().isAssignableFrom(parameter.getClass())) {
+                    return constructNewInstance(constructor, parameter);
+                }
+            }
+        }
+        return null;
+    }
+
+
 }

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.schema.GraphQLFieldDefinition;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import java.util.List;
+import java.util.Map;
+
+import static graphql.Scalars.GraphQLString;
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.testng.Assert.assertEquals;
+
+public class GraphQLExtensionsTest {
+
+    @GraphQLDescription("TestObject object")
+    @GraphQLName("TestObject")
+    private static class TestObject {
+        @GraphQLField
+        public
+        String field() {
+            return "test";
+        }
+
+    }
+
+    @GraphQLTypeExtension(GraphQLExtensionsTest.TestObject.class)
+    private static class TestObjectExtension {
+        @GraphQLField
+        public static String field2() {
+            return "test2";
+        }
+    }
+
+    @Test
+    public void fields() {
+        GraphQLAnnotations.getInstance().registerTypeExtension(TestObjectExtension.class);
+        GraphQLObjectType object = GraphQLAnnotations.object(GraphQLExtensionsTest.TestObject.class);
+        GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
+
+        List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
+        assertEquals(fields.size(), 2);
+
+        fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
+
+        assertEquals(fields.get(0).getName(), "field");
+        assertEquals(fields.get(1).getName(), "field2");
+        assertEquals(fields.get(1).getType(), GraphQLString);
+
+    }
+
+    @Test
+    public void values() {
+        GraphQLAnnotations.getInstance().registerTypeExtension(TestObjectExtension.class);
+        GraphQLObjectType object = GraphQLAnnotations.object(GraphQLExtensionsTest.TestObject.class);
+        GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
+
+        GraphQLSchema schema = newSchema().query(object).build();
+        GraphQLSchema schemaInherited = newSchema().query(object).build();
+
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field}", new GraphQLExtensionsTest.TestObject());
+        assertEquals(((Map<String, Object>) result.getData()).get("field"), "test");
+        ExecutionResult result2 = GraphQL.newGraphQL(schema).build().execute("{field2}", new GraphQLExtensionsTest.TestObject());
+        assertEquals(((Map<String, Object>) result2.getData()).get("field2"), "test2");
+    }
+
+}

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -32,7 +32,7 @@ public class GraphQLExtensionsTest {
 
     @GraphQLDescription("TestObject object")
     @GraphQLName("TestObject")
-    private static class TestObject {
+    public static class TestObject {
         @GraphQLField
         public
         String field() {
@@ -42,11 +42,12 @@ public class GraphQLExtensionsTest {
     }
 
     @GraphQLTypeExtension(GraphQLExtensionsTest.TestObject.class)
-    private static class TestObjectExtension {
+    public static class TestObjectExtension {
         private TestObject obj;
 
         public TestObjectExtension(TestObject obj) {
             this.obj = obj;
+            this.field4 = obj.field() + " test4";
         }
 
         @GraphQLField
@@ -57,6 +58,16 @@ public class GraphQLExtensionsTest {
         @GraphQLDataFetcher(TestDataFetcher.class)
         @GraphQLField
         private String field3;
+
+        @GraphQLField
+        public String field4;
+
+        @GraphQLField
+        public String field5;
+
+        public String getField5() {
+            return obj.field() + " test5";
+        }
     }
 
     public static class TestDataFetcher implements DataFetcher {
@@ -73,7 +84,7 @@ public class GraphQLExtensionsTest {
         GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
 
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
-        assertEquals(fields.size(), 3);
+        assertEquals(fields.size(), 5);
 
         fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
 
@@ -93,12 +104,13 @@ public class GraphQLExtensionsTest {
         GraphQLSchema schema = newSchema().query(object).build();
         GraphQLSchema schemaInherited = newSchema().query(object).build();
 
-        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field}", new GraphQLExtensionsTest.TestObject());
-        assertEquals(((Map<String, Object>) result.getData()).get("field"), "test");
-        ExecutionResult result2 = GraphQL.newGraphQL(schema).build().execute("{field2}", new GraphQLExtensionsTest.TestObject());
-        assertEquals(((Map<String, Object>) result2.getData()).get("field2"), "test test2");
-        ExecutionResult result3 = GraphQL.newGraphQL(schema).build().execute("{field3}", new GraphQLExtensionsTest.TestObject());
-        assertEquals(((Map<String, Object>) result3.getData()).get("field3"), "test test3");
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field field2 field3 field4 field5}", new GraphQLExtensionsTest.TestObject());
+        Map<String, Object> data = (Map<String, Object>) result.getData();
+        assertEquals(data.get("field"), "test");
+        assertEquals(data.get("field2"), "test test2");
+        assertEquals(data.get("field3"), "test test3");
+        assertEquals(data.get("field4"), "test test4");
+        assertEquals(data.get("field5"), "test test5");
     }
 
 }

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -16,9 +16,7 @@ package graphql.annotations;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
+import graphql.schema.*;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -56,6 +54,16 @@ public class GraphQLExtensionsTest {
             return obj.field() + " test2";
         }
 
+        @GraphQLDataFetcher(TestDataFetcher.class)
+        @GraphQLField
+        private String field3;
+    }
+
+    public static class TestDataFetcher implements DataFetcher {
+        @Override
+        public Object get(DataFetchingEnvironment environment) {
+            return ((TestObject)environment.getSource()).field() + " test3";
+        }
     }
 
     @Test
@@ -65,13 +73,15 @@ public class GraphQLExtensionsTest {
         GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
 
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
-        assertEquals(fields.size(), 2);
+        assertEquals(fields.size(), 3);
 
         fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
 
         assertEquals(fields.get(0).getName(), "field");
         assertEquals(fields.get(1).getName(), "field2");
         assertEquals(fields.get(1).getType(), GraphQLString);
+        assertEquals(fields.get(2).getName(), "field3");
+        assertEquals(fields.get(2).getType(), GraphQLString);
     }
 
     @Test
@@ -87,6 +97,8 @@ public class GraphQLExtensionsTest {
         assertEquals(((Map<String, Object>) result.getData()).get("field"), "test");
         ExecutionResult result2 = GraphQL.newGraphQL(schema).build().execute("{field2}", new GraphQLExtensionsTest.TestObject());
         assertEquals(((Map<String, Object>) result2.getData()).get("field2"), "test test2");
+        ExecutionResult result3 = GraphQL.newGraphQL(schema).build().execute("{field3}", new GraphQLExtensionsTest.TestObject());
+        assertEquals(((Map<String, Object>) result3.getData()).get("field3"), "test test3");
     }
 
 }

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -45,10 +45,17 @@ public class GraphQLExtensionsTest {
 
     @GraphQLTypeExtension(GraphQLExtensionsTest.TestObject.class)
     private static class TestObjectExtension {
-        @GraphQLField
-        public static String field2() {
-            return "test2";
+        private TestObject obj;
+
+        public TestObjectExtension(TestObject obj) {
+            this.obj = obj;
         }
+
+        @GraphQLField
+        public String field2() {
+            return obj.field() + " test2";
+        }
+
     }
 
     @Test
@@ -65,7 +72,6 @@ public class GraphQLExtensionsTest {
         assertEquals(fields.get(0).getName(), "field");
         assertEquals(fields.get(1).getName(), "field2");
         assertEquals(fields.get(1).getType(), GraphQLString);
-
     }
 
     @Test
@@ -80,7 +86,7 @@ public class GraphQLExtensionsTest {
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field}", new GraphQLExtensionsTest.TestObject());
         assertEquals(((Map<String, Object>) result.getData()).get("field"), "test");
         ExecutionResult result2 = GraphQL.newGraphQL(schema).build().execute("{field2}", new GraphQLExtensionsTest.TestObject());
-        assertEquals(((Map<String, Object>) result2.getData()).get("field2"), "test2");
+        assertEquals(((Map<String, Object>) result2.getData()).get("field2"), "test test2");
     }
 
 }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -19,7 +19,7 @@ import graphql.GraphQL;
 import graphql.Scalars;
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.FieldDataFetcher;
+
 import graphql.schema.GraphQLArgument;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInputObjectType;
@@ -28,13 +28,10 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
-import graphql.schema.PropertyDataFetcher;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
 import java.lang.reflect.AnnotatedType;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -197,8 +194,8 @@ public class GraphQLObjectTest {
         assertEquals(fields.get(5).getName(), "privateTest");
         assertEquals(fields.get(6).getName(), "publicTest");
 
-        assertEquals(fields.get(5).getDataFetcher().getClass(), PropertyDataFetcher.class);
-        assertEquals(fields.get(6).getDataFetcher().getClass(), FieldDataFetcher.class);
+        assertEquals(fields.get(5).getDataFetcher().getClass(), ExtensionDataFetcherWrapper.class);
+        assertEquals(fields.get(6).getDataFetcher().getClass(), ExtensionDataFetcherWrapper.class);
 
         assertEquals(fields.get(7).getName(), "z_nonOptionalString");
         assertTrue(fields.get(7).getType() instanceof graphql.schema.GraphQLNonNull);


### PR DESCRIPTION
The idea here is to be able to extend existing type by registering "extensions" classes before creating the objects with the GraphQLAnnotationsProcessor. Let's say  you have an annotated class "TestObject" in a third party module, defined by : 
type TestObject {
	field: String
}

And you need to add some fields on it without being able to change the TestObject class, as stated in this GraphQL schema :
extend type TestObject {
	field2: String
}

You could register a class, which declares "extend type TestObject" with an annotation, and defines the field2.

A new annotation is added to declare this type of objects, and they can be registered in GraphQLAnnotations. When the objects are created, we take all fields from the extension and add them to the object.

An example is provided in the test class.
