### PR TITLE
Use class simple name instead of name for fixing references

### DIFF
--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -306,7 +306,7 @@ public class DefaultTypeFunction implements TypeFunction {
         @Override
         public String getTypeName(Class<?> aClass, AnnotatedType annotatedType) {
             GraphQLName name = aClass.getAnnotation(GraphQLName.class);
-            return toGraphqlName(name == null ? aClass.getName() : name.value());
+            return toGraphqlName(name == null ? aClass.getSimpleName() : name.value());
         }
 
         @Override


### PR DESCRIPTION
ObjectFunction.getTypeName() generates a name using getName() instead of getSimpleName(), as everywhere else - this is ok as long as it is internal to this class, but this leads to an error when a GraphQLTypeReference is created. A reference to an invalid name is created and the schema cannot be built. 
