### PR TITLE
Keep all output types in registry, move type resolution from TypeFunctions to GraphQLAnnotations

### DIFF
--- a/src/main/java/graphql/annotations/BatchedTypeFunction.java
+++ b/src/main/java/graphql/annotations/BatchedTypeFunction.java
@@ -37,7 +37,7 @@ public class BatchedTypeFunction implements TypeFunction {
     }
 
     @Override
-    public graphql.schema.GraphQLType buildType(String typeName, final Class<?> aClass, final AnnotatedType annotatedType) {
+    public graphql.schema.GraphQLType buildType(final boolean inputType, final Class<?> aClass, final AnnotatedType annotatedType) {
         if (!aClass.isAssignableFrom(List.class)) {
             throw new IllegalArgumentException("Batched method should return a List");
         }
@@ -52,7 +52,6 @@ public class BatchedTypeFunction implements TypeFunction {
         } else {
             klass = (Class<?>) arg.getType();
         }
-        typeName = klass.getSimpleName();
-        return defaultTypeFunction.buildType(typeName, klass, arg);
+        return defaultTypeFunction.buildType(inputType, klass, arg);
     }
 }

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -260,12 +260,7 @@ public class DefaultTypeFunction implements TypeFunction {
 
         @Override
         public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
-            try {
-                return annotationsProcessor.getOutputTypeOrRef(aClass);
-            } catch (ClassCastException e) {
-                // Also try to resolve to input object
-                return annotationsProcessor.getInputObject(aClass);
-            }
+            return annotationsProcessor.getOutputTypeOrRef(aClass);
         }
     }
 

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -80,7 +80,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLString;
         }
     }
@@ -98,7 +98,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLBoolean;
         }
     }
@@ -116,7 +116,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLFloat;
         }
     }
@@ -134,7 +134,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLInt;
         }
     }
@@ -152,7 +152,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLLong;
         }
     }
@@ -168,7 +168,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             if (!(annotatedType instanceof AnnotatedParameterizedType)) {
                 throw new IllegalArgumentException("List type parameter should be specified");
             }
@@ -180,7 +180,7 @@ public class DefaultTypeFunction implements TypeFunction {
             } else {
                 klass = (Class<?>) arg.getType();
             }
-            return new GraphQLList(DefaultTypeFunction.this.buildType(klass, arg));
+            return new GraphQLList(DefaultTypeFunction.this.buildType(inputType, klass, arg));
         }
     }
 
@@ -192,7 +192,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             if (!(annotatedType instanceof AnnotatedParameterizedType)) {
                 throw new IllegalArgumentException("Stream type parameter should be specified");
             }
@@ -204,7 +204,7 @@ public class DefaultTypeFunction implements TypeFunction {
             } else {
                 klass = (Class<?>) arg.getType();
             }
-            return new GraphQLList(DefaultTypeFunction.this.buildType(klass, arg));
+            return new GraphQLList(DefaultTypeFunction.this.buildType(inputType, klass, arg));
         }
     }
 
@@ -222,9 +222,9 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             AnnotatedType arg = getAnnotatedType(annotatedType);
-            return DefaultTypeFunction.this.buildType(typeName, getClass(annotatedType), arg);
+            return DefaultTypeFunction.this.buildType(inputType, getClass(annotatedType), arg);
         }
 
         private AnnotatedType getAnnotatedType(AnnotatedType annotatedType) {
@@ -259,12 +259,11 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
-            try {
-                return annotationsProcessor.getOutputTypeOrRef(aClass);
-            } catch (ClassCastException e) {
-                // Also try to resolve to input object
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
+            if (inputType) {
                 return annotationsProcessor.getInputObject(aClass);
+            } else {
+                return annotationsProcessor.getOutputTypeOrRef(aClass);
             }
         }
     }
@@ -322,13 +321,13 @@ public class DefaultTypeFunction implements TypeFunction {
     }
 
     @Override
-    public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+    public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
         TypeFunction typeFunction = getTypeFunction(aClass, annotatedType);
         if (typeFunction == null) {
             throw new IllegalArgumentException("unsupported type");
         }
 
-        GraphQLType result = typeFunction.buildType(typeName, aClass, annotatedType);
+        GraphQLType result = typeFunction.buildType(inputType, aClass, annotatedType);
         if (aClass.getAnnotation(GraphQLNonNull.class) != null ||
                 (annotatedType != null && annotatedType.getAnnotation(GraphQLNonNull.class) != null)) {
             result = new graphql.schema.GraphQLNonNull(result);

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -260,7 +260,12 @@ public class DefaultTypeFunction implements TypeFunction {
 
         @Override
         public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
-            return annotationsProcessor.getOutputTypeOrRef(aClass);
+            try {
+                return annotationsProcessor.getOutputTypeOrRef(aClass);
+            } catch (ClassCastException e) {
+                // Also try to resolve to input object
+                return annotationsProcessor.getInputObject(aClass);
+            }
         }
     }
 

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -62,7 +62,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return Scalars.GraphQLID;
         }
     }

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -379,7 +379,12 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
         for (Class<?> iface : object.getInterfaces()) {
             if (iface.getAnnotation(GraphQLTypeResolver.class) != null) {
-                builder.withInterface((GraphQLInterfaceType) getInterface(iface));
+                String ifaceName = getTypeName(iface);
+                if (processing.contains(ifaceName)) {
+                    builder.withInterface(new GraphQLTypeReference(ifaceName));
+                } else {
+                    builder.withInterface((GraphQLInterfaceType) getInterface(iface));
+                }
                 builder.fields(getExtensionFields(iface, fieldsDefined));
             }
         }

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -51,6 +51,8 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
     private static final List<Class> TYPES_FOR_CONNECTION = Arrays.asList(GraphQLObjectType.class, GraphQLInterfaceType.class, GraphQLUnionType.class, GraphQLTypeReference.class);
 
+    private static final String DEFAULT_INPUT_PREFIX = "Input";
+
     private Map<String, graphql.schema.GraphQLType> typeRegistry = new HashMap<>();
     private Map<Class<?>, Set<Class<?>>> extensionsTypeRegistry = new HashMap<>();
     private final Stack<String> processing = new Stack<>();
@@ -630,7 +632,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                 filter(p -> !DataFetchingEnvironment.class.isAssignableFrom(p.getType())).
                 map(parameter -> {
                     Class<?> t = parameter.getType();
-                    graphql.schema.GraphQLType graphQLType = getInputObject(finalTypeFunction.buildType(t, parameter.getAnnotatedType()), "");
+                    graphql.schema.GraphQLType graphQLType = getInputObject(finalTypeFunction.buildType(t, parameter.getAnnotatedType()), DEFAULT_INPUT_PREFIX);
                     return getArgument(parameter, graphQLType);
                 }).collect(Collectors.toList());
 
@@ -697,12 +699,12 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
     }
 
     public GraphQLInputObjectType getInputObject(Class<?> object) {
-        String typeName = getTypeName(object);
+        String typeName = DEFAULT_INPUT_PREFIX + getTypeName(object);
         if (typeRegistry.containsKey(typeName)) {
             return (GraphQLInputObjectType) typeRegistry.get(typeName);
         } else {
             graphql.schema.GraphQLType graphQLType = getObject(object);
-            GraphQLInputObjectType inputObject = (GraphQLInputObjectType) getInputObject(graphQLType, "");
+            GraphQLInputObjectType inputObject = (GraphQLInputObjectType) getInputObject(graphQLType, DEFAULT_INPUT_PREFIX);
             typeRegistry.put(inputObject.getName(), inputObject);
             return inputObject;
         }

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -107,6 +107,17 @@ public interface GraphQLAnnotationsProcessor {
     GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
+     * This will examine the object class and return a {@link GraphQLInputType} representation
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLInputType} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLInputObjectType getInputObject(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
      * This will turn a {@link GraphQLObjectType} into a corresponding {@link GraphQLInputObjectType}
      *
      * @param graphQLType the graphql object type

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -106,6 +106,17 @@ public interface GraphQLAnnotationsProcessor {
     GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
+     * This will examine the object class and return a {@link GraphQLInputType} representation
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLInputType} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLInputObjectType getInputObject(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
      * This will turn a {@link GraphQLObjectType} into a corresponding {@link GraphQLInputObjectType}
      *
      * @param graphQLType the graphql object type

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -14,24 +14,11 @@
  */
 package graphql.annotations;
 
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLUnionType;
+import graphql.schema.*;
 
 public interface GraphQLAnnotationsProcessor {
     /**
-     * This will examine the class and if its annotated with {@link GraphQLUnion} it will return
-     * a {@link GraphQLUnionType.Builder}, if its annotated with {@link GraphQLTypeResolver} it will return
-     * a {@link GraphQLObjectType} otherwise it will return a {@link GraphQLInterfaceType.Builder}.
-     *
-     * @param iface interface to examine
-     *
-     * @return a GraphQLType that represents that interface
-     *
-     * @throws GraphQLAnnotationsException if the interface cannot be examined
-     * @throws IllegalArgumentException    if <code>iface</code> is not an interface
+     * @deprecated See {@link #getOutputType(Class)}
      */
     graphql.schema.GraphQLType getInterface(Class<?> iface) throws GraphQLAnnotationsException;
 
@@ -60,19 +47,27 @@ public interface GraphQLAnnotationsProcessor {
     GraphQLInterfaceType.Builder getIfaceBuilder(Class<?> iface) throws GraphQLAnnotationsException, IllegalArgumentException;
 
     /**
-     * This will examine the object class and return a {@link GraphQLObjectType} representation
+     * This will examine the object class and return a {@link GraphQLEnumType.Builder} ready for further definition
      *
      * @param object the object class to examine
      *
-     * @return a {@link GraphQLObjectType} that represents that object class
+     * @return a {@link GraphQLEnumType.Builder} that represents that object class
      *
      * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLEnumType.Builder getEnumBuilder(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
+     * @deprecated See {@link #getOutputType(Class)}
      */
     GraphQLObjectType getObject(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
-     * This will examine the object class and return a {@link GraphQLOutputType} representation
-     * which may be a {@link GraphQLObjectType} or a {@link graphql.schema.GraphQLTypeReference}
+     * This will examine the object and will return a {@link GraphQLOutputType} based on the class type and annotations.
+     * - If its annotated with {@link GraphQLUnion} it will return a {@link GraphQLUnionType}
+     * - If its annotated with {@link GraphQLTypeResolver} it will return a {@link GraphQLInterfaceType}
+     * - It it's an Enum it will return a {@link GraphQLEnumType},
+     * otherwise it will return a {@link GraphQLObjectType}.
      *
      * @param object the object class to examine
      *
@@ -80,7 +75,24 @@ public interface GraphQLAnnotationsProcessor {
      *
      * @throws GraphQLAnnotationsException if the object class cannot be examined
      */
+    GraphQLOutputType getOutputType(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
+     * @deprecated See {@link #getOutputTypeOrRef(Class)}
+     */
     GraphQLOutputType getObjectOrRef(Class<?> object) throws GraphQLAnnotationsException;
+
+    /**
+     * This will examine the object class and return a {@link GraphQLOutputType} representation
+     * which may be a {@link GraphQLOutputType} or a {@link graphql.schema.GraphQLTypeReference}
+     *
+     * @param object the object class to examine
+     *
+     * @return a {@link GraphQLOutputType} that represents that object class
+     *
+     * @throws GraphQLAnnotationsException if the object class cannot be examined
+     */
+    GraphQLOutputType getOutputTypeOrRef(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
      * This will examine the object class and return a {@link GraphQLObjectType.Builder} ready for further definition

--- a/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotationsProcessor.java
@@ -15,6 +15,7 @@
 package graphql.annotations;
 
 import graphql.schema.*;
+import graphql.schema.GraphQLType;
 
 public interface GraphQLAnnotationsProcessor {
     /**
@@ -106,17 +107,6 @@ public interface GraphQLAnnotationsProcessor {
     GraphQLObjectType.Builder getObjectBuilder(Class<?> object) throws GraphQLAnnotationsException;
 
     /**
-     * This will examine the object class and return a {@link GraphQLInputType} representation
-     *
-     * @param object the object class to examine
-     *
-     * @return a {@link GraphQLInputType} that represents that object class
-     *
-     * @throws GraphQLAnnotationsException if the object class cannot be examined
-     */
-    GraphQLInputObjectType getInputObject(Class<?> object) throws GraphQLAnnotationsException;
-
-    /**
      * This will turn a {@link GraphQLObjectType} into a corresponding {@link GraphQLInputObjectType}
      *
      * @param graphQLType the graphql object type
@@ -124,7 +114,7 @@ public interface GraphQLAnnotationsProcessor {
      *
      * @return a {@link GraphQLInputObjectType}
      */
-    GraphQLInputObjectType getInputObject(GraphQLObjectType graphQLType, String newNamePrefix);
+    GraphQLInputType getInputObject(GraphQLType graphQLType, String newNamePrefix);
 
     /**
      * Register a new type extension class. This extension will be used when the extended object will be created.

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -16,6 +16,7 @@ package graphql.annotations;
 
 import graphql.schema.DataFetcher;
 import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.GraphQLInputObjectType;
 import graphql.schema.GraphQLObjectType;
 
 import java.lang.reflect.Constructor;
@@ -78,7 +79,7 @@ class MethodDataFetcher implements DataFetcher {
                 continue;
             }
             graphql.schema.GraphQLType graphQLType = typeFunction.buildType(paramType, p.getAnnotatedType());
-            if (graphQLType instanceof GraphQLObjectType) {
+            if (graphQLType instanceof GraphQLInputObjectType) {
                 Constructor<?> constructor = constructor(paramType, HashMap.class);
                 result.add(constructNewInstance(constructor, envArgs.next()));
 

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -95,7 +95,7 @@ class MethodDataFetcher implements DataFetcher {
                     Map map = (Map) arg;
                     for (Parameter parameter : parameters) {
                         String name = toGraphqlName(parameter.getAnnotation(GraphQLName.class) != null ? parameter.getAnnotation(GraphQLName.class).value() : parameter.getName());
-                        objects.add(buildArg(parameter.getType(), ((GraphQLInputObjectType)graphQLType).getField(name).getType(),map.get(name)));
+                        objects.add(buildArg(parameter.getParameterizedType(), ((GraphQLInputObjectType)graphQLType).getField(name).getType(),map.get(name)));
                     }
                     return constructNewInstance(constructor, objects.toArray(new Object[objects.size()]));
                 }

--- a/src/main/java/graphql/annotations/MethodDataFetcher.java
+++ b/src/main/java/graphql/annotations/MethodDataFetcher.java
@@ -70,7 +70,8 @@ class MethodDataFetcher implements DataFetcher {
                 result.add(environment);
                 continue;
             }
-            graphql.schema.GraphQLType graphQLType = typeFunction.buildType(paramType, p.getAnnotatedType());
+
+            graphql.schema.GraphQLType graphQLType = typeFunction.buildType(true, paramType, p.getAnnotatedType());
             Object arg = envArgs.next();
             result.add(buildArg(p.getParameterizedType(), graphQLType, arg));
         }

--- a/src/main/java/graphql/annotations/TypeFunction.java
+++ b/src/main/java/graphql/annotations/TypeFunction.java
@@ -43,21 +43,21 @@ public interface TypeFunction {
 
     /**
      * Build a {@link GraphQLType} object from a java type.
-     * This is a convenience method for calling {@link #buildType(String, Class, AnnotatedType)} without a type name.
+     * This is a convenience method for calling {@link #buildType(boolean, Class, AnnotatedType)} without a type name.
      * @param aClass The java type to build the type name for
      * @param annotatedType The {@link AnnotatedType} of the java type, which may be a {link AnnotatedParameterizedType}
      * @return The built {@link GraphQLType}
      */
     default GraphQLType buildType(Class<?> aClass, AnnotatedType annotatedType) {
-        return buildType(getTypeName(aClass, annotatedType), aClass, annotatedType);
+        return buildType(false, aClass, annotatedType);
     }
 
     /**
      * Build a {@link GraphQLType} object from a java type.
-     * @param typeName The name to give the graphql type
+     * @param input is InputType
      * @param aClass The java type to build the type name for
      * @param annotatedType The {@link AnnotatedType} of the java type, which may be a {link AnnotatedParameterizedType}
      * @return The built {@link GraphQLType}
      */
-    GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType);
+    GraphQLType buildType(boolean input, Class<?> aClass, AnnotatedType annotatedType);
 }

--- a/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
+++ b/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
@@ -16,6 +16,8 @@ package graphql.annotations;
 
 import graphql.schema.*;
 import graphql.schema.GraphQLType;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.Field;
@@ -29,6 +31,11 @@ import static graphql.Scalars.GraphQLID;
 import static org.testng.Assert.*;
 
 public class DefaultTypeFunctionTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     private enum A {
         @GraphQLName("someA") @GraphQLDescription("a") A, B

--- a/src/test/java/graphql/annotations/GraphQLBatchedTest.java
+++ b/src/test/java/graphql/annotations/GraphQLBatchedTest.java
@@ -20,6 +20,8 @@ import graphql.GraphQL;
 import graphql.execution.batched.BatchedExecutionStrategy;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -33,6 +35,12 @@ import static org.testng.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class GraphQLBatchedTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
+
     private static class SimpleBatchedField {
         @GraphQLField
         @GraphQLBatched

--- a/src/test/java/graphql/annotations/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLConnectionTest.java
@@ -22,6 +22,7 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -36,6 +37,11 @@ import static org.testng.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class GraphQLConnectionTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     public static class Obj {
         @GraphQLField

--- a/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
@@ -21,6 +21,7 @@ import graphql.schema.DataFetchingEnvironment;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.PropertyDataFetcher;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -31,6 +32,11 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 public class GraphQLDataFetcherTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     @Test
     public void shouldUsePreferredConstructor() {

--- a/src/test/java/graphql/annotations/GraphQLEnumTest.java
+++ b/src/test/java/graphql/annotations/GraphQLEnumTest.java
@@ -17,6 +17,8 @@ package graphql.annotations;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.schema.*;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.lang.reflect.AnnotatedType;
@@ -30,6 +32,10 @@ import static org.testng.Assert.assertEquals;
 
 public class GraphQLEnumTest {
 
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     public enum Foo {
         ONE,

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -5,7 +5,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *     http://www.apache.org/licenses/LICENSE-2.0
+ * http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -35,8 +35,7 @@ public class GraphQLExtensionsTest {
     @GraphQLName("TestObject")
     public static class TestObject {
         @GraphQLField
-        public
-        String field() {
+        public String field() {
             return "test";
         }
 
@@ -88,15 +87,16 @@ public class GraphQLExtensionsTest {
     public static class TestDataFetcher implements DataFetcher {
         @Override
         public Object get(DataFetchingEnvironment environment) {
-            return ((TestObject)environment.getSource()).field() + " test3";
+            return ((TestObject) environment.getSource()).field() + " test3";
         }
     }
 
     @Test
     public void fields() {
-        GraphQLAnnotations.getInstance().registerTypeExtension(TestObjectExtension.class);
-        GraphQLObjectType object = GraphQLAnnotations.object(GraphQLExtensionsTest.TestObject.class);
-        GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
+        GraphQLAnnotations instance = new GraphQLAnnotations();
+        instance.registerTypeExtension(TestObjectExtension.class);
+        GraphQLObjectType object = instance.getObject(GraphQLExtensionsTest.TestObject.class);
+        instance.unregisterTypeExtension(TestObjectExtension.class);
 
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 5);
@@ -112,9 +112,10 @@ public class GraphQLExtensionsTest {
 
     @Test
     public void values() {
-        GraphQLAnnotations.getInstance().registerTypeExtension(TestObjectExtension.class);
-        GraphQLObjectType object = GraphQLAnnotations.object(GraphQLExtensionsTest.TestObject.class);
-        GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtension.class);
+        GraphQLAnnotations instance = new GraphQLAnnotations();
+        instance.registerTypeExtension(TestObjectExtension.class);
+        GraphQLObjectType object = instance.getObject(GraphQLExtensionsTest.TestObject.class);
+        instance.unregisterTypeExtension(TestObjectExtension.class);
 
         GraphQLSchema schema = newSchema().query(object).build();
         GraphQLSchema schemaInherited = newSchema().query(object).build();
@@ -130,9 +131,10 @@ public class GraphQLExtensionsTest {
 
     @Test
     public void testDuplicateField() {
-        GraphQLAnnotations.getInstance().registerTypeExtension(TestObjectExtensionInvalid.class);
-        GraphQLAnnotationsException e = expectThrows(GraphQLAnnotationsException.class, () -> GraphQLAnnotations.object(TestObject.class));
+        GraphQLAnnotations instance = new GraphQLAnnotations();
+        instance.registerTypeExtension(TestObjectExtensionInvalid.class);
+        GraphQLAnnotationsException e = expectThrows(GraphQLAnnotationsException.class, () -> instance.getObject(TestObject.class));
         assertTrue(e.getMessage().startsWith("Duplicate field"));
-        GraphQLAnnotations.getInstance().unregisterTypeExtension(TestObjectExtensionInvalid.class);
+        instance.unregisterTypeExtension(TestObjectExtensionInvalid.class);
     }
 }

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -21,6 +21,7 @@ import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.TypeResolver;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
@@ -34,6 +35,11 @@ import static org.testng.AssertJUnit.assertEquals;
 
 
 public class GraphQLFragmentTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     static Map<String, GraphQLObjectType> registry;
 

--- a/src/test/java/graphql/annotations/GraphQLInputTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInputTest.java
@@ -1,0 +1,149 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.TypeResolutionEnvironment;
+import graphql.schema.*;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+@SuppressWarnings("unchecked")
+public class GraphQLInputTest {
+
+    public static class Resolver implements TypeResolver {
+
+        @Override
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            try {
+                return GraphQLAnnotations.object(TestObject.class);
+            } catch (GraphQLAnnotationsException e) {
+                return null;
+            }
+        }
+    }
+
+    static class InputObject {
+        public InputObject(HashMap map) {
+            key = (String) map.get("key");
+        }
+
+        @GraphQLField
+        private String key;
+    }
+
+    static class RecursiveInputObject {
+        public RecursiveInputObject(HashMap map) {
+            key = (String) map.get("key");
+            if (map.containsKey("rec")) {
+                rec = new RecursiveInputObject((HashMap) map.get("rec"));
+            }
+        }
+
+        @GraphQLField
+        private String key;
+
+        @GraphQLField
+        private RecursiveInputObject rec;
+    }
+
+    @GraphQLTypeResolver(Resolver.class)
+    interface TestIface {
+        @GraphQLField
+        String value(InputObject input);
+    }
+
+    static class TestObject implements TestIface {
+
+        @Override
+        public String value(InputObject input) {
+            return input.key + "a";
+        }
+    }
+
+    static class TestObjectRec {
+        @GraphQLField
+        public String value(RecursiveInputObject input) {
+            return (input.rec != null ? ("rec"+input.rec.key) : input.key) + "a";
+        }
+    }
+
+    static class Query {
+        @GraphQLField
+        public TestIface object() {
+            return new TestObject();
+        };
+    }
+
+    static class QueryRecursion {
+        @GraphQLField
+        public TestObjectRec object() {
+            return new TestObjectRec();
+        };
+    }
+
+    static class QueryIface {
+        @GraphQLField
+        public TestObject iface() {
+            return new TestObject();
+        }
+    }
+
+
+    @Test
+    public void query() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ object { value(input:{key:\"test\"}) } }", new Query());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "testa");
+    }
+
+    @Test
+    public void queryWithRecursion() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryRecursion.class)).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ object { value(input:{key:\"test\"}) } }", new QueryRecursion());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "testa");
+
+        result = graphQL.execute("{ object { value(input:{rec:{key:\"test\"}}) } }", new QueryRecursion());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "rectesta");
+    }
+
+    @Test
+    public void queryWithInterface() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryIface.class)).build(Collections.singleton(GraphQLAnnotations.object(TestObject.class)));
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ iface { value(input:{key:\"test\"}) } }", new QueryIface());
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("iface").get("value"), "testa");
+    }
+
+
+}

--- a/src/test/java/graphql/annotations/GraphQLInputTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInputTest.java
@@ -79,6 +79,13 @@ public class GraphQLInputTest {
         }
     }
 
+    static class TestObjectList {
+        @GraphQLField
+        public String value(List<List<List<InputObject>>> input) {
+            return input.get(0).get(0).get(0).key + "a";
+        }
+    }
+
     static class TestObjectRec {
         @GraphQLField
         public String value(RecursiveInputObject input) {
@@ -124,6 +131,13 @@ public class GraphQLInputTest {
         };
     }
 
+    static class QueryList {
+        @GraphQLField
+        public TestObjectList object() {
+            return new TestObjectList();
+        };
+    }
+
     static class QueryIface {
         @GraphQLField
         public TestObject iface() {
@@ -165,6 +179,15 @@ public class GraphQLInputTest {
         result = graphQL.execute("{ object { value(input:{rec:{key:\"test\"}}) } }", new QueryRecursion());
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "rectesta");
+    }
+
+    @Test
+    public void queryWithList() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryList.class)).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ object { value(input:[[[{key:\"test\"}]]]) } }", new QueryList());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "testa");
     }
 
     @Test

--- a/src/test/java/graphql/annotations/GraphQLInputTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInputTest.java
@@ -41,13 +41,26 @@ public class GraphQLInputTest {
         }
     }
 
+    static class SubInputObject {
+        public SubInputObject(String subKey) {
+            this.subKey = subKey;
+        }
+
+        @GraphQLField
+        private String subKey;
+    }
+
     static class InputObject {
-        public InputObject(HashMap map) {
-            key = (String) map.get("key");
+        public InputObject(String key, List<SubInputObject> complex) {
+            this.key = key;
+            this.complex = complex;
         }
 
         @GraphQLField
         private String key;
+
+        @GraphQLField
+        private List<SubInputObject> complex;
     }
 
     static class RecursiveInputObject {
@@ -82,7 +95,8 @@ public class GraphQLInputTest {
     static class TestObjectList {
         @GraphQLField
         public String value(List<List<List<InputObject>>> input) {
-            return input.get(0).get(0).get(0).key + "a";
+            InputObject inputObject = input.get(0).get(0).get(0);
+            return inputObject.key + "-" + inputObject.complex.get(0).subKey;
         }
     }
 
@@ -186,8 +200,8 @@ public class GraphQLInputTest {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryList.class)).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ object { value(input:[[[{key:\"test\"}]]]) } }", new QueryList());
-        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "testa");
+        ExecutionResult result = graphQL.execute("{ object { value(input:[[[{key:\"test\", complex:[{subKey:\"subtest\"},{subKey:\"subtest2\"}]}]]]) } }", new QueryList());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("object").get("value"), "test-subtest");
     }
 
     @Test

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -26,6 +26,7 @@ import graphql.schema.GraphQLOutputType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLUnionType;
 import graphql.schema.TypeResolver;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.List;
@@ -34,9 +35,15 @@ import java.util.Map;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @SuppressWarnings("unchecked")
 public class GraphQLInterfaceTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     interface NoResolverIface {
         @GraphQLField

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -546,18 +546,41 @@ public class GraphQLObjectTest {
         @GraphQLField
         public int b;
 
-        public TestInputArgument(HashMap<String, Object> args) {
-            a = (String) args.get("a");
-            b = (int) args.get("b");
+        public TestInputArgument(String a, int b) {
+            this.a = a;
+            this.b = b;
         }
     }
+
+    private static class TestComplexInputArgument {
+
+        public Collection<TestInputArgument> inputs;
+
+        public TestComplexInputArgument(Collection<TestInputArgument> inputs) {
+            this.inputs = inputs;
+        }
+
+        @GraphQLField
+        public Collection<TestInputArgument> getInputs() {
+            return inputs;
+        }
+
+    }
+
+
 
     private static class TestObjectInput {
         @GraphQLField
         public String test(int other, TestInputArgument arg) {
             return arg.a;
         }
+
+        @GraphQLField
+        public String test2(int other, TestComplexInputArgument arg) {
+            return arg.inputs.iterator().next().a;
+        }
     }
+
 
     @Test
     public void inputObjectArgument() {
@@ -571,6 +594,20 @@ public class GraphQLObjectTest {
         assertTrue(result.getErrors().isEmpty());
         Map<String, Object> v = (Map<String, Object>) result.getData();
         assertEquals(v.get("test"), "ok");
+    }
+
+    @Test
+    public void complexInputObjectArgument() {
+        GraphQLObjectType object = GraphQLAnnotations.object(TestObjectInput.class);
+        GraphQLArgument argument = object.getFieldDefinition("test2").getArgument("arg");
+        assertTrue(argument.getType() instanceof GraphQLInputObjectType);
+        assertEquals(argument.getName(), "arg");
+
+        GraphQLSchema schema = newSchema().query(object).build();
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{ test2(arg: {inputs:[{ a:\"ok\", b:2 }]}, other:0) }", new TestObjectInput());
+        assertTrue(result.getErrors().isEmpty());
+        Map<String, Object> v = (Map<String, Object>) result.getData();
+        assertEquals(v.get("test2"), "ok");
     }
 
     @Test

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -625,7 +625,7 @@ public class GraphQLObjectTest {
         }
 
         @Override
-        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+        public GraphQLType buildType(boolean inputType, Class<?> aClass, AnnotatedType annotatedType) {
             return GraphQLString;
         }
     }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -28,6 +28,7 @@ import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
@@ -49,6 +50,11 @@ import static org.testng.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class GraphQLObjectTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     public static class DefaultAValue implements Supplier<Object> {
 

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -33,11 +33,7 @@ import org.testng.annotations.Test;
 
 import javax.validation.constraints.NotNull;
 import java.lang.reflect.AnnotatedType;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 import java.util.function.Supplier;
 
 import static graphql.Scalars.GraphQLString;

--- a/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
+++ b/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
@@ -17,12 +17,19 @@ package graphql.annotations;
 import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.schema.GraphQLObjectType;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
 
 public class GraphQLSimpleSchemaTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
+
 
     public static class User {
 

--- a/src/test/java/graphql/annotations/MethodDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/MethodDataFetcherTest.java
@@ -15,12 +15,19 @@
 package graphql.annotations;
 
 import graphql.schema.DataFetchingEnvironmentImpl;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class MethodDataFetcherTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
+
 
     public class TestException extends Exception {
     }

--- a/src/test/java/graphql/annotations/RelayTest.java
+++ b/src/test/java/graphql/annotations/RelayTest.java
@@ -20,6 +20,7 @@ import graphql.TypeResolutionEnvironment;
 import graphql.schema.*;
 import graphql.schema.GraphQLNonNull;
 import graphql.schema.GraphQLType;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
@@ -29,6 +30,11 @@ import static org.testng.Assert.*;
 
 @SuppressWarnings("unchecked")
 public class RelayTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
 
     public static class ResultTypeResolver implements TypeResolver {
 


### PR DESCRIPTION
Here's some change proposition related to the issue : #92  . The changes are significant but should not be breaking, api compatibility is kept and all tests pass.

Basically the idea is : 
- Keep all generated GraphQLOutputType in the GraphQLAnnotations local registry
- Enum support is added to GraphQLAnnotations
- A single method "getOutputType()" return a GraphQLOutputType for all supported stuff : objects, interfaces, unions, enum, and registers it in the registry
- Previous methods getObject() and getInterface() delegates to getOutputType() and are marked as deprecated
- ObjectFunction completely delegates to GraphQLAnnotations to create return types or references to types (also handle enums). No duplicate registry in the DefaultTypeFunction

One change was required in the tests : cleanup the registry before executing any new test, as all object types are now kept here and we have many tests defining different ObjectType with the same name.

