### PR TITLE
Relay connections : support recursive and interfaces connection, pass arguments to DataFetcher

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -82,6 +82,8 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
     private static final Relay RELAY_TYPES = new Relay();
 
+    private static final List<Class> TYPES_FOR_CONNECTION = Arrays.asList(GraphQLObjectType.class, GraphQLInterfaceType.class, GraphQLUnionType.class, GraphQLTypeReference.class);
+
     private Map<String, graphql.schema.GraphQLType> typeRegistry = new HashMap<>();
     private final Stack<String> processing = new Stack<>();
 
@@ -510,11 +512,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
     private boolean isConnection(AccessibleObject obj, Class<?> klass, GraphQLOutputType type) {
         return obj.isAnnotationPresent(GraphQLConnection.class) &&
-                type instanceof GraphQLList &&
-                (((GraphQLList) type).getWrappedType() instanceof GraphQLObjectType ||
-                        ((GraphQLList) type).getWrappedType() instanceof GraphQLInterfaceType ||
-                        ((GraphQLList) type).getWrappedType() instanceof GraphQLUnionType ||
-                        ((GraphQLList) type).getWrappedType() instanceof GraphQLTypeReference);
+                type instanceof GraphQLList && TYPES_FOR_CONNECTION.stream().anyMatch(aClass -> aClass.isInstance(((GraphQLList) type).getWrappedType()));
     }
 
     protected GraphQLFieldDefinition getField(Method method) throws GraphQLAnnotationsException {

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -511,7 +511,10 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
     private boolean isConnection(AccessibleObject obj, Class<?> klass, GraphQLOutputType type) {
         return obj.isAnnotationPresent(GraphQLConnection.class) &&
                 type instanceof GraphQLList &&
-                ((GraphQLList) type).getWrappedType() instanceof GraphQLObjectType;
+                (((GraphQLList) type).getWrappedType() instanceof GraphQLObjectType ||
+                        ((GraphQLList) type).getWrappedType() instanceof GraphQLInterfaceType ||
+                        ((GraphQLList) type).getWrappedType() instanceof GraphQLUnionType ||
+                        ((GraphQLList) type).getWrappedType() instanceof GraphQLTypeReference);
     }
 
     protected GraphQLFieldDefinition getField(Method method) throws GraphQLAnnotationsException {
@@ -708,7 +711,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         @Override
         public Object get(DataFetchingEnvironment environment) {
             // Exclude arguments
-            DataFetchingEnvironment env = new DataFetchingEnvironmentImpl(environment.getSource(), new HashMap<>(), environment.getContext(),
+            HashMap<String, Object> arguments = new HashMap<>(environment.getArguments());
+            arguments.keySet().removeAll(Arrays.asList("first", "last", "before", "after"));
+            DataFetchingEnvironment env = new DataFetchingEnvironmentImpl(environment.getSource(), arguments, environment.getContext(),
                     environment.getFields(), environment.getFieldType(), environment.getParentType(), environment.getGraphQLSchema(),
                     environment.getFragmentsByName(), environment.getExecutionId(), environment.getSelectionSet());
             Connection conn = constructNewInstance(constructor, actualDataFetcher.get(env));

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -710,7 +710,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
         @Override
         public Object get(DataFetchingEnvironment environment) {
-            // Exclude arguments
+            // Create a list of arguments with connection specific arguments excluded
             HashMap<String, Object> arguments = new HashMap<>(environment.getArguments());
             arguments.keySet().removeAll(Arrays.asList("first", "last", "before", "after"));
             DataFetchingEnvironment env = new DataFetchingEnvironmentImpl(environment.getSource(), arguments, environment.getContext(),


### PR DESCRIPTION
Small fixes on connections : 
- Pass arguments to connection data fetcher ( #33 )
- Support recursive and interfaces connection ( `isConnection` allows interface, union and ref) 