### PR TITLE
OSGi DS 1.2 compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import java.text.SimpleDateFormat
+import aQute.bnd.gradle.Bundle
 
 buildscript {
     repositories {
@@ -155,4 +156,9 @@ bintray {
             released  = new Date()
         }
     }
+}
+
+task bundle(type: Bundle) {
+  from sourceSets.main.output
+  bndfile = file('bundle.bnd')
 }

--- a/bundle.bnd
+++ b/bundle.bnd
@@ -1,0 +1,3 @@
+Export-Package: graphql.annotations.*;version="3.0.3"
+Bundle-SymbolicName: graphql.annotations
+-nouses=true

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -22,8 +22,8 @@ import graphql.schema.GraphQLTypeReference;
 import org.osgi.service.component.annotations.Activate;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
-import org.osgi.service.component.annotations.ServiceScope;
+import org.osgi.service.component.annotations.ReferenceCardinality;
+import org.osgi.service.component.annotations.ReferencePolicy;
 
 import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
@@ -41,11 +41,9 @@ import java.util.stream.Stream;
 import static graphql.annotations.util.NamingKit.toGraphqlName;
 import static graphql.schema.GraphQLEnumType.newEnum;
 
-@Component(scope = ServiceScope.SINGLETON, property = "type=default")
+@Component(property = "type=default")
 public class DefaultTypeFunction implements TypeFunction {
 
-    @Reference(target = "(!(type=default))",
-            policyOption = ReferencePolicyOption.GREEDY)
     protected List<TypeFunction> otherFunctions = new ArrayList<>();
 
     private CopyOnWriteArrayList<TypeFunction> typeFunctions;
@@ -353,6 +351,18 @@ public class DefaultTypeFunction implements TypeFunction {
         typeFunctions.add(new OptionalFunction());
 
         typeFunctions.add(new ObjectFunction());
+    }
+
+    @Reference(cardinality = ReferenceCardinality.MULTIPLE,
+            policy = ReferencePolicy.DYNAMIC,
+            service = TypeFunction.class,
+            target = "(!(type=default))")
+    void addFunction(TypeFunction function) {
+        this.otherFunctions.add(function);
+    }
+
+    void removeFunction(TypeFunction function) {
+        this.otherFunctions.remove(function);
     }
 
     @Activate


### PR DESCRIPTION
At the moment the library is relying on the OSGi annotations that were introduced in the OSGi DS _1.3_ which makes it _impossible_ to deploy inside Equinox container that is widely used by many organisations.
This PR does two things:

- Introduces DS _1.2_ compatibility
- Adds _bundle_ task and _bundle.bnd_ file to package the library as OSGi bundle using Gradle and BND tool.
- Preserve binary and functional compatibility with older versions.