### PR TITLE
Add support for wrapping lists with object types as input objects

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -631,6 +631,8 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                             GraphQLInputType inputType;
                             if (type instanceof GraphQLObjectType) {
                                 inputType = getInputObject((GraphQLObjectType) type, newNamePrefix);
+							} else if (type instanceof GraphQLList && ((GraphQLList) type).getWrappedType() instanceof GraphQLObjectType) {
+								inputType = GraphQLList.list(getInputObject((GraphQLObjectType)((GraphQLList) type).getWrappedType(), newNamePrefix));
                             } else {
                                 inputType = (GraphQLInputType) type;
                             }


### PR DESCRIPTION
Currently using an object containing list fields with other objects causes an invalid GraphQL schema, because the list item objects are not defined as input objects. This change recursively constructs input objects for objects inside lists.