### PR TITLE
GraphQLID support

### DIFF
--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -65,7 +65,7 @@ public class DefaultTypeFunction implements TypeFunction {
         public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
             return annotatedType != null
                     && (aClass == Integer.class || aClass == int.class || aClass == String.class)
-                    && (annotatedType.getAnnotation(GraphQLID.class) != null);
+                    && annotatedType.isAnnotationPresent(GraphQLID.class);
         }
 
         @Override

--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -29,11 +29,7 @@ import java.lang.reflect.AnnotatedParameterizedType;
 import java.lang.reflect.AnnotatedType;
 import java.lang.reflect.Field;
 import java.lang.reflect.ParameterizedType;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.stream.Stream;
@@ -57,6 +53,25 @@ public class DefaultTypeFunction implements TypeFunction {
 
     void setAnnotationsProcessor(GraphQLAnnotationsProcessor annotationsProcessor) {
         this.annotationsProcessor = annotationsProcessor;
+    }
+
+    private class IDFunction implements TypeFunction {
+        @Override
+        public String getTypeName(Class<?> aClass, AnnotatedType annotatedType) {
+            return Scalars.GraphQLID.getName();
+        }
+
+        @Override
+        public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
+            return annotatedType != null
+                    && (aClass == Integer.class || aClass == int.class || aClass == String.class)
+                    && (annotatedType.getAnnotation(GraphQLID.class) != null);
+        }
+
+        @Override
+        public GraphQLType buildType(String typeName, Class<?> aClass, AnnotatedType annotatedType) {
+            return Scalars.GraphQLID;
+        }
     }
 
     private class StringFunction implements TypeFunction {
@@ -336,6 +351,7 @@ public class DefaultTypeFunction implements TypeFunction {
     public DefaultTypeFunction() {
         typeFunctions = new CopyOnWriteArrayList<>();
 
+        typeFunctions.add(new IDFunction());
         typeFunctions.add(new StringFunction());
         typeFunctions.add(new BooleanFunction());
         typeFunctions.add(new FloatFunction());

--- a/src/main/java/graphql/annotations/GraphQLID.java
+++ b/src/main/java/graphql/annotations/GraphQLID.java
@@ -1,0 +1,12 @@
+package graphql.annotations;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE_USE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLID {
+    boolean value() default true;
+}

--- a/src/main/java/graphql/annotations/GraphQLID.java
+++ b/src/main/java/graphql/annotations/GraphQLID.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import java.lang.annotation.ElementType;

--- a/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
+++ b/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
+++ b/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -14,10 +14,13 @@
  */
 package graphql.annotations;
 
+import com.sun.corba.se.impl.orbutil.graph.Graph;
 import graphql.schema.*;
 import graphql.schema.GraphQLType;
 import org.testng.annotations.Test;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
 import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -31,6 +34,21 @@ public class DefaultTypeFunctionTest {
         @GraphQLName("someA") @GraphQLDescription("a") A, B
     }
 
+    public @GraphQLID String idStringMethod() {
+        return "asd";
+    }
+
+    public @GraphQLID Integer idIntegerMethod() {
+        return 5;
+    }
+
+    public @GraphQLID int idIntMethod() {
+        return 5;
+    }
+
+    public @GraphQLID String idStringField;
+    public @GraphQLID Integer idIntegerField;
+    public @GraphQLID int idIntField;
 
     @Test
     public void enumeration() {
@@ -39,12 +57,31 @@ public class DefaultTypeFunctionTest {
         assertTrue(enumeration instanceof GraphQLEnumType);
         List<GraphQLEnumValueDefinition> values = ((GraphQLEnumType) enumeration).getValues();
         assertEquals(values.stream().
-                     map(GraphQLEnumValueDefinition::getName).collect(Collectors.toList()),
-                     Arrays.asList("someA", "B"));
+                        map(GraphQLEnumValueDefinition::getName).collect(Collectors.toList()),
+                Arrays.asList("someA", "B"));
         assertEquals(values.stream().
                         map(GraphQLEnumValueDefinition::getDescription).collect(Collectors.toList()),
                 Arrays.asList("a", "B"));
 
+    }
+
+    @Test
+    public void id() throws NoSuchMethodException, NoSuchFieldException {
+        DefaultTypeFunction instace = testedDefaultTypeFunction();
+        Method idStringMethod = DefaultTypeFunctionTest.class.getMethod("idStringMethod");
+        Method idIntegerMethod = DefaultTypeFunctionTest.class.getMethod("idIntegerMethod");
+        Method idIntMethod = DefaultTypeFunctionTest.class.getMethod("idIntMethod");
+        Field idStringField = DefaultTypeFunctionTest.class.getField("idStringField");
+        Field idIntegerField = DefaultTypeFunctionTest.class.getField("idIntegerField");
+        Field idIntField = DefaultTypeFunctionTest.class.getField("idIntField");
+
+        assertEquals(instace.buildType(idStringMethod.getReturnType(), idStringMethod.getAnnotatedReturnType()), GraphQLID);
+        assertEquals(instace.buildType(idIntegerMethod.getReturnType(), idIntegerMethod.getAnnotatedReturnType()), GraphQLID);
+        assertEquals(instace.buildType(idIntMethod.getReturnType(), idIntMethod.getAnnotatedReturnType()), GraphQLID);
+
+        assertEquals(instace.buildType(idStringField.getType(), idStringField.getAnnotatedType()), GraphQLID);
+        assertEquals(instace.buildType(idIntegerField.getType(), idIntegerField.getAnnotatedType()), GraphQLID);
+        assertEquals(instace.buildType(idIntField.getType(), idIntField.getAnnotatedType()), GraphQLID);
     }
 
     @Test
@@ -85,20 +122,30 @@ public class DefaultTypeFunctionTest {
 
 
     @SuppressWarnings("unused")
-    public List<List<@GraphQLNonNull String>> listMethod() { return null;}
+    public List<List<@GraphQLNonNull String>> listMethod() {
+        return null;
+    }
 
     @SuppressWarnings("unused")
-    public Iterable<Iterable<@GraphQLNonNull String>> iterableMethod() { return null;}
+    public Iterable<Iterable<@GraphQLNonNull String>> iterableMethod() {
+        return null;
+    }
 
     @SuppressWarnings("unused")
-    public Collection<Collection<@GraphQLNonNull String>> collectionMethod() { return null;}
+    public Collection<Collection<@GraphQLNonNull String>> collectionMethod() {
+        return null;
+    }
 
 
     @SuppressWarnings("unused")
-    public Stream<List<@GraphQLNonNull String>> streamMethod() { return null;}
+    public Stream<List<@GraphQLNonNull String>> streamMethod() {
+        return null;
+    }
 
     @SuppressWarnings("unused")
-    public Set<Set<@GraphQLNonNull String>> setMethod() { return null;}
+    public Set<Set<@GraphQLNonNull String>> setMethod() {
+        return null;
+    }
 
     // GraphqlList(GraphqlList(GraphQlString) is expected here
     private void assertIsGraphListOfListOfString(GraphQLType type) {
@@ -153,7 +200,9 @@ public class DefaultTypeFunctionTest {
     }
 
     @SuppressWarnings("unused")
-    public Optional<List<@GraphQLNonNull String>> optionalMethod() { return Optional.empty();}
+    public Optional<List<@GraphQLNonNull String>> optionalMethod() {
+        return Optional.empty();
+    }
 
     @Test
     public void optional() throws NoSuchMethodException {
@@ -193,8 +242,8 @@ public class DefaultTypeFunctionTest {
         GraphQLType type = instance.buildType(Class1.class, Class2.class.getField("class1").getAnnotatedType());
         GraphQLFieldDefinition class1class2 = ((GraphQLObjectType) type).getFieldDefinition("class2");
         assertNotNull(class1class2);
-        assertTrue(((GraphQLObjectType)class1class2.getType()).getFieldDefinition("class1").getType() instanceof GraphQLTypeReference);
-        assertTrue(((GraphQLObjectType)class1class2.getType()).getFieldDefinition("class2").getType() instanceof GraphQLTypeReference);
+        assertTrue(((GraphQLObjectType) class1class2.getType()).getFieldDefinition("class1").getType() instanceof GraphQLTypeReference);
+        assertTrue(((GraphQLObjectType) class1class2.getType()).getFieldDefinition("class2").getType() instanceof GraphQLTypeReference);
         GraphQLAnnotations.instance = new GraphQLAnnotations();
     }
 

--- a/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
+++ b/src/test/java/graphql/annotations/DefaultTypeFunctionTest.java
@@ -14,7 +14,6 @@
  */
 package graphql.annotations;
 
-import com.sun.corba.se.impl.orbutil.graph.Graph;
 import graphql.schema.*;
 import graphql.schema.GraphQLType;
 import org.testng.annotations.Test;
@@ -26,6 +25,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.Scalars.*;
+import static graphql.Scalars.GraphQLID;
 import static org.testng.Assert.*;
 
 public class DefaultTypeFunctionTest {
@@ -66,39 +66,80 @@ public class DefaultTypeFunctionTest {
     }
 
     @Test
-    public void id() throws NoSuchMethodException, NoSuchFieldException {
-        DefaultTypeFunction instace = testedDefaultTypeFunction();
+    public void buildType_stringMethodAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchMethodException, NoSuchFieldException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
         Method idStringMethod = DefaultTypeFunctionTest.class.getMethod("idStringMethod");
-        Method idIntegerMethod = DefaultTypeFunctionTest.class.getMethod("idIntegerMethod");
-        Method idIntMethod = DefaultTypeFunctionTest.class.getMethod("idIntMethod");
-        Field idStringField = DefaultTypeFunctionTest.class.getField("idStringField");
-        Field idIntegerField = DefaultTypeFunctionTest.class.getField("idIntegerField");
-        Field idIntField = DefaultTypeFunctionTest.class.getField("idIntField");
 
-        assertEquals(instace.buildType(idStringMethod.getReturnType(), idStringMethod.getAnnotatedReturnType()), GraphQLID);
-        assertEquals(instace.buildType(idIntegerMethod.getReturnType(), idIntegerMethod.getAnnotatedReturnType()), GraphQLID);
-        assertEquals(instace.buildType(idIntMethod.getReturnType(), idIntMethod.getAnnotatedReturnType()), GraphQLID);
-
-        assertEquals(instace.buildType(idStringField.getType(), idStringField.getAnnotatedType()), GraphQLID);
-        assertEquals(instace.buildType(idIntegerField.getType(), idIntegerField.getAnnotatedType()), GraphQLID);
-        assertEquals(instace.buildType(idIntField.getType(), idIntField.getAnnotatedType()), GraphQLID);
+        // Act+Assert
+        assertEquals(instance.buildType(idStringMethod.getReturnType(), idStringMethod.getAnnotatedReturnType()), GraphQLID);
     }
 
     @Test
-    public void string() {
+    public void buildType_integerMethodAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchMethodException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
+        Method idIntegerMethod = DefaultTypeFunctionTest.class.getMethod("idIntegerMethod");
+
+        // Act+Assert
+        assertEquals(instance.buildType(idIntegerMethod.getReturnType(), idIntegerMethod.getAnnotatedReturnType()), GraphQLID);
+    }
+
+    @Test
+    public void buildType_intMethodAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchMethodException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
+        Method idIntMethod = DefaultTypeFunctionTest.class.getMethod("idIntMethod");
+
+        // Act+Assert
+        assertEquals(instance.buildType(idIntMethod.getReturnType(), idIntMethod.getAnnotatedReturnType()), GraphQLID);
+    }
+
+    @Test
+    public void buildType_stringFieldAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchFieldException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
+        Field idStringField = DefaultTypeFunctionTest.class.getField("idStringField");
+
+        // Act+Assert
+        assertEquals(instance.buildType(idStringField.getType(), idStringField.getAnnotatedType()), GraphQLID);
+    }
+
+    @Test
+    public void buildType_integerFieldAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchFieldException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
+        Field idIntegerField = DefaultTypeFunctionTest.class.getField("idIntegerField");
+
+        // Act+Assert
+        assertEquals(instance.buildType(idIntegerField.getType(), idIntegerField.getAnnotatedType()), GraphQLID);
+    }
+
+    @Test
+    public void buildType_intFieldAnnotatedWithGraphQLID_returnsGraphQLID() throws NoSuchFieldException {
+        // Arrange
+        DefaultTypeFunction instance = testedDefaultTypeFunction();
+        Field idIntField = DefaultTypeFunctionTest.class.getField("idIntField");
+
+        // Act+Assert
+        assertEquals(instance.buildType(idIntField.getType(), idIntField.getAnnotatedType()), GraphQLID);
+    }
+
+    @Test
+    public void buildType_stringType_returnsGraphQLString() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         assertEquals(instance.buildType(String.class, null), GraphQLString);
     }
 
     @Test
-    public void bool() {
+    public void buildType_booleanType_returnsGraphQLBoolean() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         assertEquals(instance.buildType(boolean.class, null), GraphQLBoolean);
         assertEquals(instance.buildType(Boolean.class, null), GraphQLBoolean);
     }
 
     @Test
-    public void float_() {
+    public void buildType_floatType_returnsGraphQLFloat() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         assertEquals(instance.buildType(float.class, null), GraphQLFloat);
         assertEquals(instance.buildType(Float.class, null), GraphQLFloat);
@@ -107,14 +148,14 @@ public class DefaultTypeFunctionTest {
     }
 
     @Test
-    public void integer() {
+    public void buildType_integerType_returnsGraphQLInt() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         assertEquals(instance.buildType(int.class, null), GraphQLInt);
         assertEquals(instance.buildType(Integer.class, null), GraphQLInt);
     }
 
     @Test
-    public void long_() {
+    public void buildType_longType_returnsGraphQLLong() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         assertEquals(instance.buildType(long.class, null), GraphQLLong);
         assertEquals(instance.buildType(Long.class, null), GraphQLLong);
@@ -157,7 +198,7 @@ public class DefaultTypeFunctionTest {
     }
 
     @Test
-    public void list() throws NoSuchMethodException {
+    public void buildType_listType_returnsCorrectGraphQLType() throws NoSuchMethodException {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         graphql.schema.GraphQLType type = instance.buildType(getClass().getMethod("listMethod").getReturnType(), getClass().getMethod("listMethod").getAnnotatedReturnType());
         assertIsGraphListOfListOfString(type);
@@ -165,28 +206,28 @@ public class DefaultTypeFunctionTest {
 
 
     @Test
-    public void iterable() throws NoSuchMethodException {
+    public void buildType_iterableType_returnsCorrectGraphQLType() throws NoSuchMethodException {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         graphql.schema.GraphQLType type = instance.buildType(getClass().getMethod("iterableMethod").getReturnType(), getClass().getMethod("iterableMethod").getAnnotatedReturnType());
         assertIsGraphListOfListOfString(type);
     }
 
     @Test
-    public void collection() throws NoSuchMethodException {
+    public void buildType_collectionType_returnsCorrectGraphQLType() throws NoSuchMethodException {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         graphql.schema.GraphQLType type = instance.buildType(getClass().getMethod("collectionMethod").getReturnType(), getClass().getMethod("collectionMethod").getAnnotatedReturnType());
         assertIsGraphListOfListOfString(type);
     }
 
     @Test
-    public void set() throws NoSuchMethodException {
+    public void buildType_setType_returnsCorrectGraphQLType() throws NoSuchMethodException {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         graphql.schema.GraphQLType type = instance.buildType(getClass().getMethod("setMethod").getReturnType(), getClass().getMethod("setMethod").getAnnotatedReturnType());
         assertIsGraphListOfListOfString(type);
     }
 
     @Test
-    public void stream() throws NoSuchMethodException {
+    public void buildType_streamType_returnsCorrectGraphQLType() throws NoSuchMethodException {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
         graphql.schema.GraphQLType type = instance.buildType(getClass().getMethod("streamMethod").getReturnType(), getClass().getMethod("listMethod").getAnnotatedReturnType());
         assertIsGraphListOfListOfString(type);


### PR DESCRIPTION
Adds support for GraphQLID (exists in graphql-java).
Adds an annotation @GraphQLID you can put before a method/field with String/Integer/int type.
For example:
`private @GraphQLID String id;
`
It will be represented as an ID scalar.

Fixes issue https://github.com/graphql-java/graphql-java-annotations/issues/71