### PR TITLE
Fixes Null / NonNull on GraphQLConnection

### DIFF
--- a/src/main/java/graphql/annotations/DefaultTypeFunction.java
+++ b/src/main/java/graphql/annotations/DefaultTypeFunction.java
@@ -328,8 +328,7 @@ public class DefaultTypeFunction implements TypeFunction {
         }
 
         GraphQLType result = typeFunction.buildType(inputType, aClass, annotatedType);
-        if (aClass.getAnnotation(GraphQLNonNull.class) != null ||
-                (annotatedType != null && annotatedType.getAnnotation(GraphQLNonNull.class) != null)) {
+        if (annotatedType != null && annotatedType.isAnnotationPresent(GraphQLNonNull.class)) {
             result = new graphql.schema.GraphQLNonNull(result);
         }
         return result;

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -582,15 +582,13 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
             type = (GraphQLOutputType) ((GraphQLNonNull) type).getWrappedType();
         }
 
-        if (type instanceof GraphQLList) {
-            graphql.schema.GraphQLType wrappedType = ((GraphQLList) type).getWrappedType();
-            assert wrappedType instanceof GraphQLObjectType;
-            String annValue = field.getAnnotation(GraphQLConnection.class).name();
-            String connectionName = annValue.isEmpty() ? wrappedType.getName() : annValue;
-            GraphQLObjectType edgeType = relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList());
-            type = relay.connectionType(connectionName, edgeType, Collections.emptyList());
-            builder.argument(relay.getConnectionFieldArguments());
-        }
+        graphql.schema.GraphQLType wrappedType = ((GraphQLList) type).getWrappedType();
+        assert wrappedType instanceof GraphQLObjectType;
+        String annValue = field.getAnnotation(GraphQLConnection.class).name();
+        String connectionName = annValue.isEmpty() ? wrappedType.getName() : annValue;
+        GraphQLObjectType edgeType = relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList());
+        type = relay.connectionType(connectionName, edgeType, Collections.emptyList());
+        builder.argument(relay.getConnectionFieldArguments());
 
         if (isNonNull) {
             type = new GraphQLNonNull(type);

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -21,7 +21,6 @@ import graphql.schema.GraphQLNonNull;
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
 
-import javax.validation.constraints.NotNull;
 import java.lang.reflect.*;
 import java.util.*;
 import java.util.function.Function;
@@ -471,7 +470,6 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         }
 
         GraphQLOutputType outputType = (GraphQLOutputType) typeFunction.buildType(field.getType(), field.getAnnotatedType());
-        outputType = field.isAnnotationPresent(NotNull.class) ? new GraphQLNonNull(outputType) : outputType;
 
         boolean isConnection = isConnection(field, outputType);
         if (isConnection) {
@@ -629,7 +627,6 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         }
 
         GraphQLOutputType outputType = (GraphQLOutputType) outputTypeFunction.buildType(method.getReturnType(), annotatedReturnType);
-        outputType = method.getAnnotation(NotNull.class) == null ? outputType : new GraphQLNonNull(outputType);
 
         boolean isConnection = isConnection(method, outputType);
         if (isConnection) {
@@ -644,7 +641,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
                 filter(p -> !DataFetchingEnvironment.class.isAssignableFrom(p.getType())).
                 map(parameter -> {
                     Class<?> t = parameter.getType();
-                    graphql.schema.GraphQLType graphQLType = getInputObject(finalTypeFunction.buildType(t, parameter.getAnnotatedType()), DEFAULT_INPUT_PREFIX);
+                    graphql.schema.GraphQLInputType graphQLType = getInputObject(finalTypeFunction.buildType(t, parameter.getAnnotatedType()), DEFAULT_INPUT_PREFIX);
                     return getArgument(parameter, graphQLType);
                 }).collect(Collectors.toList());
 
@@ -755,10 +752,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         return (GraphQLInputObjectType) getInstance().getInputObject(graphQLType, newNamePrefix);
     }
 
-    protected GraphQLArgument getArgument(Parameter parameter, graphql.schema.GraphQLType t) throws
+    protected GraphQLArgument getArgument(Parameter parameter, graphql.schema.GraphQLInputType t) throws
             GraphQLAnnotationsException {
-        GraphQLArgument.Builder builder = newArgument();
-        builder.type(parameter.getAnnotation(NotNull.class) == null ? (GraphQLInputType) t : new graphql.schema.GraphQLNonNull(t));
+        GraphQLArgument.Builder builder = newArgument().type(t);
         GraphQLDescription description = parameter.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -600,9 +600,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         if (type instanceof GraphQLNonNull) {
             type = (GraphQLOutputType) ((GraphQLNonNull) type).getWrappedType();
         }
-        final GraphQLOutputType wrappedType = type;
+        final GraphQLOutputType actualType = type;
         return obj.isAnnotationPresent(GraphQLConnection.class) &&
-                wrappedType instanceof GraphQLList && TYPES_FOR_CONNECTION.stream().anyMatch(aClass -> aClass.isInstance(((GraphQLList) wrappedType).getWrappedType()));
+                actualType instanceof GraphQLList && TYPES_FOR_CONNECTION.stream().anyMatch(aClass -> aClass.isInstance(((GraphQLList) actualType).getWrappedType()));
     }
 
     protected GraphQLFieldDefinition getField(Method method) throws GraphQLAnnotationsException {

--- a/src/main/java/graphql/annotations/GraphQLNonNull.java
+++ b/src/main/java/graphql/annotations/GraphQLNonNull.java
@@ -19,7 +19,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-@Target({ElementType.TYPE, ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER})
+@Target({ElementType.FIELD, ElementType.TYPE_USE, ElementType.METHOD, ElementType.PARAMETER})
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLNonNull {
 }

--- a/src/test/java/graphql/annotations/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLConnectionTest.java
@@ -104,6 +104,19 @@ public class GraphQLConnectionTest {
             return this.objs.stream().filter( obj -> obj.val.startsWith(filter));
         }
 
+        @GraphQLField
+        @GraphQLConnection(name = "nonNullObjs")
+        @GraphQLNonNull
+        public List<Obj> getNonNullObjs() {
+            return this.objs;
+        }
+
+        @GraphQLField
+        @GraphQLConnection(name = "null")
+        public List<Obj> getNull() {
+            return null;
+        }
+
 
     }
 
@@ -162,6 +175,36 @@ public class GraphQLConnectionTest {
         assertTrue(result.getErrors().isEmpty());
 
         testResult("objStream", result);
+    }
+
+    @Test
+    public void methodNonNull() {
+        GraphQLObjectType object = GraphQLAnnotations.object(TestConnections.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ nonNullObjs(first: 1) { edges { cursor node { id, val } } } }",
+                new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
+
+        assertTrue(result.getErrors().isEmpty());
+
+        testResult("nonNullObjs", result);
+    }
+
+    @Test
+    public void methodNull() {
+        GraphQLObjectType object = GraphQLAnnotations.object(TestConnections.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ null(first: 1) { edges { cursor node { id, val } } } }",
+                new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
+
+        assertTrue(result.getErrors().isEmpty());
+
+        Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = result.getData();
+
+        assertEquals(data.get("null"), null);
     }
 
     @Test

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -31,7 +31,6 @@ import graphql.schema.GraphQLType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.validation.constraints.NotNull;
 import java.lang.reflect.AnnotatedType;
 import java.util.*;
 import java.util.function.Supplier;
@@ -67,13 +66,13 @@ public class GraphQLObjectTest {
         @GraphQLName("field0")
         @GraphQLDescription("field")
         public
-        @NotNull
+        @GraphQLNonNull
         String field() {
             return "test";
         }
 
         @GraphQLField
-        public String fieldWithArgs(@NotNull String a, @GraphQLDefaultValue(DefaultAValue.class) @GraphQLDescription("b") String b) {
+        public String fieldWithArgs(@GraphQLNonNull String a, @GraphQLDefaultValue(DefaultAValue.class) @GraphQLDescription("b") String b) {
             return b;
         }
 


### PR DESCRIPTION
This fixes the following issues : 
- When a field/method has GraphQLNonNull and GraphQLConnection , GraphQLConnection is ignored
- When a field/method has NotNull and GraphQLConnection , NotNull is ignored
- Returning null on a field annotated with GraphQLConnection crashes (with default DispatchingConnection )

By the way, I don't clearly understand in which cases GraphQLNonNull should be used in favour of NotNull. Looks like NotNull can be used on field/method and arguments, and GraphQLNonNull can be used on field/method (actually, on return types) and classes - so field and methods can actually have NotNull and GraphQLNonNull (and having both will result in a field wrapped twice). What is the prefered way to declare a non-null field ?
