### PR TITLE
Avoid duplicate definitions of the same types when using connections

### DIFF
--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -588,9 +588,18 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         assert wrappedType instanceof GraphQLObjectType;
         String connectionName = field.getAnnotation(GraphQLConnection.class).name();
         connectionName = connectionName.isEmpty() ? wrappedType.getName() : connectionName;
-        GraphQLObjectType edgeType = relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList());
-        type = relay.connectionType(connectionName, edgeType, Collections.emptyList());
+        GraphQLObjectType edgeType = ensureTypeUniqueness(relay.edgeType(connectionName, (GraphQLOutputType) wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList()));
+        type = ensureTypeUniqueness(relay.connectionType(connectionName, edgeType, Collections.emptyList()));
         builder.argument(relay.getConnectionFieldArguments());
+        return type;
+    }
+
+    private GraphQLObjectType ensureTypeUniqueness(GraphQLObjectType type) {
+        if (typeRegistry.containsKey(type.getName())) {
+            type = (GraphQLObjectType) typeRegistry.get(type.getName());
+        } else {
+            typeRegistry.put(type.getName(), type);
+        }
         return type;
     }
 

--- a/src/main/java/graphql/annotations/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/GraphQLAnnotations.java
@@ -588,11 +588,11 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         GraphQLOutputType wrappedType = (GraphQLOutputType) listType.getWrappedType();
         String connectionName = field.getAnnotation(GraphQLConnection.class).name();
         connectionName = connectionName.isEmpty() ? wrappedType.getName() : connectionName;
-        GraphQLObjectType edgeType = ensureTypeUniqueness(relay.edgeType(connectionName, wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList()));
-        return ensureTypeUniqueness(relay.connectionType(connectionName, edgeType, Collections.emptyList()));
+        GraphQLObjectType edgeType = getActualType(relay.edgeType(connectionName, wrappedType, null, Collections.<GraphQLFieldDefinition>emptyList()));
+        return getActualType(relay.connectionType(connectionName, edgeType, Collections.emptyList()));
     }
 
-    private GraphQLObjectType ensureTypeUniqueness(GraphQLObjectType type) {
+    private GraphQLObjectType getActualType(GraphQLObjectType type) {
         if (typeRegistry.containsKey(type.getName())) {
             type = (GraphQLObjectType) typeRegistry.get(type.getName());
         } else {

--- a/src/test/java/graphql/annotations/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLConnectionTest.java
@@ -26,6 +26,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -55,12 +56,30 @@ public class GraphQLConnectionTest {
         }
     }
 
+    public static class DuplicateTest {
+        @GraphQLField
+        public TestListField field1;
+
+        @GraphQLField
+        public TestListField2 field2;
+    }
+
     public static class TestListField {
         @GraphQLField
         @GraphQLConnection
         public List<Obj> objs;
 
         public TestListField(List<Obj> objs) {
+            this.objs = objs;
+        }
+    }
+
+    public static class TestListField2 {
+        @GraphQLField
+        @GraphQLConnection
+        public List<Obj> objs;
+
+        public TestListField2(List<Obj> objs) {
             this.objs = objs;
         }
     }
@@ -268,6 +287,13 @@ public class GraphQLConnectionTest {
         Map<String, Object> objs = (Map<String, Object>) (data.get("objs"));
         List edges = (List) objs.get("edges");
         assertEquals(edges.size(), 0);
+    }
+
+    @Test
+    public void duplicateConnection() {
+        GraphQLObjectType object = GraphQLAnnotations.object(DuplicateTest.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+        System.out.println("ok");
     }
 
 }

--- a/src/test/java/graphql/annotations/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLConnectionTest.java
@@ -26,7 +26,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -35,6 +34,7 @@ import static graphql.annotations.util.RelayKit.EMPTY_CONNECTION;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 @SuppressWarnings("unchecked")
 public class GraphQLConnectionTest {
@@ -291,9 +291,12 @@ public class GraphQLConnectionTest {
 
     @Test
     public void duplicateConnection() {
-        GraphQLObjectType object = GraphQLAnnotations.object(DuplicateTest.class);
-        GraphQLSchema schema = newSchema().query(object).build();
-        System.out.println("ok");
+        try {
+            GraphQLObjectType object = GraphQLAnnotations.object(DuplicateTest.class);
+            GraphQLSchema schema = newSchema().query(object).build();
+        } catch (GraphQLAnnotationsException e) {
+            fail("Schema cannot be created",e);
+        }
     }
 
 }


### PR DESCRIPTION
The issue happens when two different type want to use the same type of connection. The connection/edge type is created multiple times, and conflicts when the schema is created. It also happen if an interface defines a connection field - each implementation will recreate an output type for the connection/edge. Simply storing the type in the typeRegistry and reusing it fixes the issue.
