### PR TITLE
changed groupid

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -85,7 +85,7 @@ publishing {
     publications {
         maven(MavenPublication) {
             from components.java
-            groupId 'com.graphql-java'
+            groupId 'io.github.graphql-java'
             artifactId project.name
             version project.version
 
@@ -145,7 +145,6 @@ bintray {
     publications = ['maven']
     publish = true
     pkg {
-        userOrg = 'graphql-java'
         desc = 'This library offers an annotations-based syntax for GraphQL schema definition.'
         repo = 'graphql-java-annotations'
         name = 'graphql-java-annotations'


### PR DESCRIPTION
changed the groupid.
In Maven the groupid is io.github.graphql-java from now on
In Bintray the groupid is the default that bintray sets from now on

@andimarek 
@bbakerman 

Please approve this if you are OK with is (or give me a comment to fix it)