### PR TITLE
Hotfix - check if the GraphQL type has extension annotation

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-group = com.graphql-java
+group = io.github.graphql-java
 
 org.gradle.caching=true
 org.gradle.daemon=true

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldDataFetcherBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldDataFetcherBuilder.java
@@ -80,7 +80,7 @@ public class FieldDataFetcherBuilder implements Builder<DataFetcher> {
         }
 
         if (actualDataFetcher == null) {
-            actualDataFetcher = wrapExtension(new PropertyDataFetcher(field.getName()), field);
+            actualDataFetcher = wrapExtension(new FieldDataFetcher(field.getName()), field);
         }
         return actualDataFetcher;
     }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -133,6 +133,43 @@ public class GraphQLObjectTest {
         }
     }
 
+    public static class TestMappedObject {
+        @GraphQLField
+        public String name;
+    }
+
+    public static class TestObjectDB{
+        public String name;
+
+        public TestObjectDB(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class TestQuery{
+        @GraphQLField
+        @GraphQLDataFetcher(ObjectFetcher.class)
+        public TestMappedObject object;
+    }
+
+    public static class ObjectFetcher implements DataFetcher<TestObjectDB> {
+
+        @Override
+        public TestObjectDB get(DataFetchingEnvironment environment) {
+            return new TestObjectDB("test");
+        }
+    }
+
+    @Test
+    public void fetchTestMappedObject_assertNameIsMappedFromDBObject(){
+        GraphQLObjectType object = GraphQLAnnotations.object(TestQuery.class);
+        GraphQLSchema schema = newSchema().query(object).build();
+
+        ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{object {name}}");
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((LinkedHashMap)(((LinkedHashMap)result.getData()).get("object"))).get("name"), "test");
+    }
+
     @Test
     public void namedFields() {
         GraphQLObjectType object = GraphQLAnnotations.object(TestObjectNamedArgs.class);

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -214,9 +214,6 @@ public class GraphQLObjectTest {
         assertEquals(fields.get(5).getName(), "privateTest");
         assertEquals(fields.get(6).getName(), "publicTest");
 
-        assertEquals(fields.get(5).getDataFetcher().getClass(), ExtensionDataFetcherWrapper.class);
-        assertEquals(fields.get(6).getDataFetcher().getClass(), ExtensionDataFetcherWrapper.class);
-
         assertEquals(fields.get(7).getName(), "z_nonOptionalString");
         assertTrue(fields.get(7).getType() instanceof graphql.schema.GraphQLNonNull);
     }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -18,22 +18,14 @@ import graphql.ExecutionResult;
 import graphql.GraphQL;
 import graphql.Scalars;
 import graphql.annotations.annotationTypes.*;
-import graphql.annotations.dataFetchers.ExtensionDataFetcherWrapper;
+import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.retrievers.GraphQLInputObjectRetriever;
 import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
+import graphql.schema.*;
 
-import graphql.schema.GraphQLArgument;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInputObjectType;
-import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLList;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
 import graphql.schema.GraphQLType;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.SchemaPrinter;
@@ -213,6 +205,9 @@ public class GraphQLObjectTest {
 
         assertEquals(fields.get(5).getName(), "privateTest");
         assertEquals(fields.get(6).getName(), "publicTest");
+
+        assertEquals(fields.get(5).getDataFetcher().getClass(), PropertyDataFetcher.class);
+        assertEquals(fields.get(6).getDataFetcher().getClass(), FieldDataFetcher.class);
 
         assertEquals(fields.get(7).getName(), "z_nonOptionalString");
         assertTrue(fields.get(7).getType() instanceof graphql.schema.GraphQLNonNull);


### PR DESCRIPTION
I found a bug - we could not map between two entities (DB entity and GraphQL entity) because the ExtensionDataFetcherWrapper tried to cast the source to the GraphQL entity where it should not do that - so we check now if the class is an extension and only then use the ExtensionDataFetcherWrapper