### PR TITLE
Better OSGi integration - 

### DIFF
--- a/src/main/java/graphql/annotations/processor/GraphQLAnnotationsComponent.java
+++ b/src/main/java/graphql/annotations/processor/GraphQLAnnotationsComponent.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.processor;
+
+import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
+import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
+import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
+import graphql.annotations.processor.typeFunctions.TypeFunction;
+import org.osgi.service.component.annotations.*;
+
+@Component(service = GraphQLAnnotationsComponent.class, immediate = true)
+public class GraphQLAnnotationsComponent {
+
+    private TypeFunction defaultTypeFunction;
+    private GraphQLOutputProcessor outputTypeProcessor;
+    private GraphQLInputProcessor inputTypeProcessor;
+    private GraphQLExtensionsHandler extensionsHandler;
+
+    public ProcessingElementsContainer createContainer() {
+        return new ProcessingElementsContainer(defaultTypeFunction);
+    }
+
+    public GraphQLOutputProcessor getOutputTypeProcessor() {
+        return outputTypeProcessor;
+    }
+
+    public GraphQLInputProcessor getInputTypeProcessor() {
+        return inputTypeProcessor;
+    }
+
+    public GraphQLExtensionsHandler getExtensionsHandler() {
+        return extensionsHandler;
+    }
+
+    @Reference(target = "(type=default)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setDefaultTypeFunction(TypeFunction defaultTypeFunction) {
+        this.defaultTypeFunction = defaultTypeFunction;
+    }
+
+    public void unsetDefaultTypeFunction(TypeFunction defaultTypeFunction) {
+        this.defaultTypeFunction = null;
+    }
+
+    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setOutputTypeProcessor(GraphQLOutputProcessor outputTypeProcessor) {
+        this.outputTypeProcessor = outputTypeProcessor;
+    }
+
+    public void unsetOutputTypeProcessor(GraphQLOutputProcessor outputTypeProcessor) {
+        this.outputTypeProcessor = null;
+    }
+
+    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setInputTypeProcessor(GraphQLInputProcessor inputTypeProcessor) {
+        this.inputTypeProcessor = inputTypeProcessor;
+    }
+
+    public void unsetInputTypeProcessor(GraphQLInputProcessor inputTypeProcessor) {
+        this.inputTypeProcessor = null;
+    }
+
+    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setExtensionsHandler(GraphQLExtensionsHandler extensionsHandler) {
+        this.extensionsHandler = extensionsHandler;
+    }
+
+    public void unsetExtensionsHandler(GraphQLExtensionsHandler extensionsHandler) {
+        this.extensionsHandler = null;
+    }
+}

--- a/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLAnnotationsProcessor.java
+++ b/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLAnnotationsProcessor.java
@@ -27,13 +27,6 @@ public interface GraphQLAnnotationsProcessor {
     void registerTypeExtension(Class<?> objectClass);
 
     /**
-     * Unregister a type extension class.
-     *
-     * @param objectClass The extension class to unregister
-     */
-    void unregisterTypeExtension(Class<?> objectClass);
-
-    /**
      * Allows you to set a custom relay object
      *
      * @param relay The extension class to register

--- a/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLInputProcessor.java
+++ b/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLInputProcessor.java
@@ -14,31 +14,25 @@
  */
 package graphql.annotations.processor.graphQLProcessors;
 
-
 import graphql.annotations.processor.ProcessingElementsContainer;
-import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.schema.GraphQLInputType;
-import graphql.schema.GraphQLType;
-import graphql.schema.GraphQLTypeReference;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
-import java.util.Map;
-
-import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
-
+@Component(service = GraphQLInputProcessor.class)
 public class GraphQLInputProcessor {
 
-
-    private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
     private GraphQLTypeRetriever graphQLTypeRetriever;
 
-    public GraphQLInputProcessor(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    public GraphQLInputProcessor(GraphQLTypeRetriever graphQLTypeRetriever) {
         this.graphQLTypeRetriever = graphQLTypeRetriever;
     }
 
     public GraphQLInputProcessor() {
-        this(new GraphQLObjectInfoRetriever(), new GraphQLTypeRetriever());
+        this(new GraphQLTypeRetriever());
     }
 
     /**
@@ -48,7 +42,6 @@ public class GraphQLInputProcessor {
      * @param container a class that hold several members that are required in order to build schema
      * @return a {@link GraphQLInputType} that represents that object class
      */
-
     public GraphQLInputType getInputTypeOrRef(Class<?> object, ProcessingElementsContainer container) {
         boolean considerAsInput = true;
         if (Enum.class.isAssignableFrom(object)) {
@@ -56,4 +49,14 @@ public class GraphQLInputProcessor {
         }
         return (GraphQLInputType) graphQLTypeRetriever.getGraphQLType(object, container, considerAsInput);
     }
+
+    @Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    public void setGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = graphQLTypeRetriever;
+    }
+
+    public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
+    }
+
 }

--- a/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLInputProcessor.java
+++ b/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLInputProcessor.java
@@ -27,14 +27,6 @@ public class GraphQLInputProcessor {
 
     private GraphQLTypeRetriever graphQLTypeRetriever;
 
-    public GraphQLInputProcessor(GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLTypeRetriever = graphQLTypeRetriever;
-    }
-
-    public GraphQLInputProcessor() {
-        this(new GraphQLTypeRetriever());
-    }
-
     /**
      * This will examine the object class and return a {@link GraphQLInputType} representation
      *
@@ -56,7 +48,7 @@ public class GraphQLInputProcessor {
     }
 
     public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
+        this.graphQLTypeRetriever = null;
     }
 
 }

--- a/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLOutputProcessor.java
+++ b/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLOutputProcessor.java
@@ -17,24 +17,25 @@ package graphql.annotations.processor.graphQLProcessors;
 
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.ProcessingElementsContainer;
-import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.retrievers.GraphQLTypeRetriever;
 import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLTypeReference;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+@Component(service = GraphQLOutputProcessor.class, immediate = true)
 public class GraphQLOutputProcessor {
 
-    private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
     private GraphQLTypeRetriever graphQLTypeRetriever;
 
 
-    public GraphQLOutputProcessor(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    public GraphQLOutputProcessor(GraphQLTypeRetriever graphQLTypeRetriever) {
         this.graphQLTypeRetriever = graphQLTypeRetriever;
     }
 
     public GraphQLOutputProcessor() {
-        this(new GraphQLObjectInfoRetriever(), new GraphQLTypeRetriever());
+        this(new GraphQLTypeRetriever());
     }
 
     /**
@@ -48,9 +49,16 @@ public class GraphQLOutputProcessor {
      *
      * @throws GraphQLAnnotationsException if the object class cannot be examined
      */
-
     public GraphQLOutputType getOutputTypeOrRef(Class<?> object, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         return (GraphQLOutputType) graphQLTypeRetriever.getGraphQLType(object, container, false);
     }
 
+    @Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)
+    public void setGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = graphQLTypeRetriever;
+    }
+
+    public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
+    }
 }

--- a/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLOutputProcessor.java
+++ b/src/main/java/graphql/annotations/processor/graphQLProcessors/GraphQLOutputProcessor.java
@@ -29,15 +29,6 @@ public class GraphQLOutputProcessor {
 
     private GraphQLTypeRetriever graphQLTypeRetriever;
 
-
-    public GraphQLOutputProcessor(GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLTypeRetriever = graphQLTypeRetriever;
-    }
-
-    public GraphQLOutputProcessor() {
-        this(new GraphQLTypeRetriever());
-    }
-
     /**
      * This will examine the object class and return a {@link GraphQLOutputType} representation
      * which may be a {@link GraphQLOutputType} or a {@link graphql.schema.GraphQLTypeReference}
@@ -59,6 +50,6 @@ public class GraphQLOutputProcessor {
     }
 
     public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
+        this.graphQLTypeRetriever = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.processor.retrievers;
+
+import graphql.annotations.annotationTypes.GraphQLTypeExtension;
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.exceptions.CannotCastMemberException;
+import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
+import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
+import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
+import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
+import graphql.schema.GraphQLFieldDefinition;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+import static graphql.annotations.processor.util.ObjectUtil.getAllFields;
+
+@Component(service = GraphQLExtensionsHandler.class, immediate = true)
+public class GraphQLExtensionsHandler {
+
+    private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
+    private SearchAlgorithm fieldSearchAlgorithm;
+    private SearchAlgorithm methodSearchAlgorithm;
+    private GraphQLFieldRetriever fieldRetriever;
+
+    public GraphQLExtensionsHandler() {
+        this(new GraphQLObjectInfoRetriever(), new ParentalSearch(new GraphQLObjectInfoRetriever()), new BreadthFirstSearch(new GraphQLObjectInfoRetriever()), new GraphQLFieldRetriever());
+    }
+
+    public GraphQLExtensionsHandler(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm fieldSearchAlgorithm, SearchAlgorithm methodSearchAlgorithm, GraphQLFieldRetriever fieldRetriever) {
+        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
+        this.methodSearchAlgorithm = methodSearchAlgorithm;
+        this.fieldRetriever = fieldRetriever;
+    }
+
+    public List<GraphQLFieldDefinition> getExtensionFields(Class<?> object, List<String> definedFields, ProcessingElementsContainer container) throws CannotCastMemberException {
+        List<GraphQLFieldDefinition> fields = new ArrayList<>();
+        if (container.getExtensionsTypeRegistry().containsKey(object)) {
+            for (Class<?> aClass : container.getExtensionsTypeRegistry().get(object)) {
+                for (Method method : graphQLObjectInfoRetriever.getOrderedMethods(aClass)) {
+                    if (method.isBridge() || method.isSynthetic()) {
+                        continue;
+                    }
+                    if (methodSearchAlgorithm.isFound(method)) {
+                        addExtensionField(fieldRetriever.getField(method, container), fields, definedFields);
+                    }
+                }
+                for (Field field : getAllFields(aClass).values()) {
+                    if (Modifier.isStatic(field.getModifiers())) {
+                        continue;
+                    }
+                    if (fieldSearchAlgorithm.isFound(field)) {
+                        addExtensionField(fieldRetriever.getField(field, container), fields, definedFields);
+                    }
+                }
+            }
+        }
+        return fields;
+    }
+
+    private void addExtensionField(GraphQLFieldDefinition gqlField, List<GraphQLFieldDefinition> fields, List<String> definedFields) {
+        if (!definedFields.contains(gqlField.getName())) {
+            definedFields.add(gqlField.getName());
+            fields.add(gqlField);
+        } else {
+            throw new GraphQLAnnotationsException("Duplicate field found in extension : " + gqlField.getName(), null);
+        }
+    }
+
+
+    public void registerTypeExtension(Class<?> objectClass, ProcessingElementsContainer container) {
+        GraphQLTypeExtension typeExtension = objectClass.getAnnotation(GraphQLTypeExtension.class);
+        if (typeExtension == null) {
+            throw new GraphQLAnnotationsException("Class is not annotated with GraphQLTypeExtension", null);
+        } else {
+            Class<?> aClass = typeExtension.value();
+            if (!container.getExtensionsTypeRegistry().containsKey(aClass)) {
+                container.getExtensionsTypeRegistry().put(aClass, new HashSet<>());
+            }
+            container.getExtensionsTypeRegistry().get(aClass).add(objectClass);
+        }
+    }
+
+    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    }
+
+    public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+    }
+
+
+    @Reference(target = "(type=field)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
+        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
+    }
+
+    public void unsetFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
+        this.fieldSearchAlgorithm = new ParentalSearch(new GraphQLObjectInfoRetriever());
+    }
+
+    @Reference(target = "(type=method)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
+        this.methodSearchAlgorithm = methodSearchAlgorithm;
+    }
+
+    public void unsetMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
+        this.methodSearchAlgorithm = new BreadthFirstSearch(new GraphQLObjectInfoRetriever());
+    }
+
+    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setFieldRetriever(GraphQLFieldRetriever fieldRetriever) {
+        this.fieldRetriever = fieldRetriever;
+    }
+
+    public void unsetFieldRetriever(GraphQLFieldRetriever fieldRetriever) {
+        this.fieldRetriever = new GraphQLFieldRetriever();
+    }
+}

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
@@ -44,17 +44,6 @@ public class GraphQLExtensionsHandler {
     private SearchAlgorithm methodSearchAlgorithm;
     private GraphQLFieldRetriever fieldRetriever;
 
-    public GraphQLExtensionsHandler() {
-        this(new GraphQLObjectInfoRetriever(), new ParentalSearch(new GraphQLObjectInfoRetriever()), new BreadthFirstSearch(new GraphQLObjectInfoRetriever()), new GraphQLFieldRetriever());
-    }
-
-    public GraphQLExtensionsHandler(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm fieldSearchAlgorithm, SearchAlgorithm methodSearchAlgorithm, GraphQLFieldRetriever fieldRetriever) {
-        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
-        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
-        this.methodSearchAlgorithm = methodSearchAlgorithm;
-        this.fieldRetriever = fieldRetriever;
-    }
-
     public List<GraphQLFieldDefinition> getExtensionFields(Class<?> object, List<String> definedFields, ProcessingElementsContainer container) throws CannotCastMemberException {
         List<GraphQLFieldDefinition> fields = new ArrayList<>();
         if (container.getExtensionsTypeRegistry().containsKey(object)) {
@@ -109,7 +98,7 @@ public class GraphQLExtensionsHandler {
     }
 
     public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
-        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+        this.graphQLObjectInfoRetriever = null;
     }
 
 
@@ -119,7 +108,7 @@ public class GraphQLExtensionsHandler {
     }
 
     public void unsetFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
-        this.fieldSearchAlgorithm = new ParentalSearch(new GraphQLObjectInfoRetriever());
+        this.fieldSearchAlgorithm = null;
     }
 
     @Reference(target = "(type=method)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -128,7 +117,7 @@ public class GraphQLExtensionsHandler {
     }
 
     public void unsetMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
-        this.methodSearchAlgorithm = new BreadthFirstSearch(new GraphQLObjectInfoRetriever());
+        this.methodSearchAlgorithm = null;
     }
 
     @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -137,6 +126,6 @@ public class GraphQLExtensionsHandler {
     }
 
     public void unsetFieldRetriever(GraphQLFieldRetriever fieldRetriever) {
-        this.fieldRetriever = new GraphQLFieldRetriever();
+        this.fieldRetriever = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLInterfaceRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLInterfaceRetriever.java
@@ -28,14 +28,6 @@ public class GraphQLInterfaceRetriever {
 
     private GraphQLTypeRetriever graphQLTypeRetriever;
 
-    public GraphQLInterfaceRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
-        this.graphQLTypeRetriever = graphQLTypeRetriever;
-    }
-
-    public GraphQLInterfaceRetriever() {
-        this(new GraphQLTypeRetriever());
-    }
-
     /**
      * This will examine the class and return a {@link graphql.schema.GraphQLOutputType} ready for further definition
      *
@@ -54,6 +46,6 @@ public class GraphQLInterfaceRetriever {
     }
 
     public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLOutputObjectRetriever) {
-        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
+        this.graphQLTypeRetriever = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLInterfaceRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLInterfaceRetriever.java
@@ -18,13 +18,18 @@ package graphql.annotations.processor.retrievers;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.schema.GraphQLOutputType;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+@Component(service = GraphQLInterfaceRetriever.class, immediate = true)
 public class GraphQLInterfaceRetriever {
 
-    private GraphQLTypeRetriever graphQLOutputObjectRetriever;
+    private GraphQLTypeRetriever graphQLTypeRetriever;
 
-    public GraphQLInterfaceRetriever(GraphQLTypeRetriever graphQLOutputObjectRetriever) {
-        this.graphQLOutputObjectRetriever = graphQLOutputObjectRetriever;
+    public GraphQLInterfaceRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = graphQLTypeRetriever;
     }
 
     public GraphQLInterfaceRetriever() {
@@ -40,6 +45,15 @@ public class GraphQLInterfaceRetriever {
      * @throws GraphQLAnnotationsException if the class cannot be examined
      */
     public graphql.schema.GraphQLOutputType getInterface(Class<?> iface, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
-        return (GraphQLOutputType) graphQLOutputObjectRetriever.getGraphQLType(iface, container, false);
+        return (GraphQLOutputType) graphQLTypeRetriever.getGraphQLType(iface, container, false);
+    }
+
+    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setGraphQLTypeRetriever(GraphQLTypeRetriever graphQLTypeRetriever) {
+        this.graphQLTypeRetriever = graphQLTypeRetriever;
+    }
+
+    public void unsetGraphQLTypeRetriever(GraphQLTypeRetriever graphQLOutputObjectRetriever) {
+        this.graphQLTypeRetriever = new GraphQLTypeRetriever();
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectHandler.java
@@ -14,12 +14,17 @@
  */
 package graphql.annotations.processor.retrievers;
 
-import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.CannotCastMemberException;
+import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLOutputType;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
+@Component(service = GraphQLObjectHandler.class, immediate = true)
 public class GraphQLObjectHandler {
 
     private GraphQLTypeRetriever typeRetriever;
@@ -40,4 +45,15 @@ public class GraphQLObjectHandler {
             throw new IllegalArgumentException("Object resolve to a " + type.getClass().getSimpleName());
         }
     }
+
+    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setTypeRetriever(GraphQLTypeRetriever typeRetriever) {
+        this.typeRetriever = typeRetriever;
+    }
+
+    public void unsetTypeRetriever(GraphQLTypeRetriever typeRetriever) {
+        this.typeRetriever = new GraphQLTypeRetriever();
+    }
+
+
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectHandler.java
@@ -29,14 +29,6 @@ public class GraphQLObjectHandler {
 
     private GraphQLTypeRetriever typeRetriever;
 
-    public GraphQLObjectHandler(GraphQLTypeRetriever typeRetriever) {
-        this.typeRetriever = typeRetriever;
-    }
-
-    public GraphQLObjectHandler() {
-        this(new GraphQLTypeRetriever());
-    }
-
     public GraphQLObjectType getObject(Class<?> object, ProcessingElementsContainer container) throws GraphQLAnnotationsException, CannotCastMemberException {
         GraphQLOutputType type = (GraphQLOutputType) typeRetriever.getGraphQLType(object, container, false);
         if (type instanceof GraphQLObjectType) {
@@ -46,13 +38,17 @@ public class GraphQLObjectHandler {
         }
     }
 
+    public GraphQLTypeRetriever getTypeRetriever() {
+        return typeRetriever;
+    }
+
     @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setTypeRetriever(GraphQLTypeRetriever typeRetriever) {
         this.typeRetriever = typeRetriever;
     }
 
     public void unsetTypeRetriever(GraphQLTypeRetriever typeRetriever) {
-        this.typeRetriever = new GraphQLTypeRetriever();
+        this.typeRetriever = null;
     }
 
 

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
@@ -17,6 +17,7 @@ package graphql.annotations.processor.retrievers;
 
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import org.osgi.service.component.annotations.Component;
 
 import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
@@ -27,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
+@Component(service = GraphQLObjectInfoRetriever.class, immediate = true)
 public class GraphQLObjectInfoRetriever {
 
     public String getTypeName(Class<?> objectClass) {

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
@@ -19,8 +19,6 @@ import graphql.annotations.annotationTypes.GraphQLUnion;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.CannotCastMemberException;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
-import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
-import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
 import graphql.annotations.processor.typeBuilders.*;
 import graphql.schema.*;
@@ -41,19 +39,6 @@ public class GraphQLTypeRetriever {
     private SearchAlgorithm methodSearchAlgorithm;
     private GraphQLExtensionsHandler extensionsHandler;
 
-
-    public GraphQLTypeRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, GraphQLInterfaceRetriever graphQLInterfaceRetriever, GraphQLFieldRetriever graphQLFieldRetriever, SearchAlgorithm fieldSearchAlgorithm, SearchAlgorithm methodSearchAlgorithm, GraphQLExtensionsHandler extensionsHandler) {
-        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
-        this.graphQLInterfaceRetriever = graphQLInterfaceRetriever;
-        this.graphQLFieldRetriever = graphQLFieldRetriever;
-        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
-        this.methodSearchAlgorithm = methodSearchAlgorithm;
-        this.extensionsHandler = extensionsHandler;
-    }
-
-    public GraphQLTypeRetriever() {
-        this(new GraphQLObjectInfoRetriever(), new GraphQLInterfaceRetriever(), new GraphQLFieldRetriever(),  new ParentalSearch(new GraphQLObjectInfoRetriever()), new BreadthFirstSearch(new GraphQLObjectInfoRetriever()), new GraphQLExtensionsHandler());
-    }
 
     /**
      * This will examine the object and will return a {@link GraphQLType} based on the class type and annotationTypes.
@@ -96,10 +81,10 @@ public class GraphQLTypeRetriever {
             type = new EnumBuilder(graphQLObjectInfoRetriever).getEnumBuilder(object).build();
         } else {
             if (isInput) {
-                type = new InputObjectBuilder(graphQLObjectInfoRetriever, methodSearchAlgorithm, fieldSearchAlgorithm,
+                type = new InputObjectBuilder(graphQLObjectInfoRetriever, fieldSearchAlgorithm, methodSearchAlgorithm,
                         graphQLFieldRetriever).getInputObjectBuilder(object, container).build();
             } else {
-                type = new OutputObjectBuilder(graphQLObjectInfoRetriever, methodSearchAlgorithm, fieldSearchAlgorithm,
+                type = new OutputObjectBuilder(graphQLObjectInfoRetriever, fieldSearchAlgorithm, methodSearchAlgorithm,
                         graphQLFieldRetriever, graphQLInterfaceRetriever, extensionsHandler).getOutputObjectBuilder(object, container).build();
             }
         }
@@ -110,6 +95,17 @@ public class GraphQLTypeRetriever {
         return type;
     }
 
+    public GraphQLObjectInfoRetriever getGraphQLObjectInfoRetriever() {
+        return graphQLObjectInfoRetriever;
+    }
+
+    public GraphQLInterfaceRetriever getGraphQLInterfaceRetriever() {
+        return graphQLInterfaceRetriever;
+    }
+
+    public GraphQLFieldRetriever getGraphQLFieldRetriever() {
+        return graphQLFieldRetriever;
+    }
 
     @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
@@ -117,7 +113,7 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
-        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+        this.graphQLObjectInfoRetriever = null;
     }
 
     @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -126,7 +122,7 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetGraphQLInterfaceRetriever(GraphQLInterfaceRetriever graphQLInterfaceRetriever) {
-        this.graphQLInterfaceRetriever = new GraphQLInterfaceRetriever();
+        this.graphQLInterfaceRetriever = null;
     }
 
     @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -135,7 +131,7 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetGraphQLFieldRetriever(GraphQLFieldRetriever graphQLFieldRetriever) {
-        this.graphQLFieldRetriever = new GraphQLFieldRetriever();
+        this.graphQLFieldRetriever = null;
     }
 
     @Reference(target = "(type=field)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -144,7 +140,7 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
-        this.fieldSearchAlgorithm = new ParentalSearch(new GraphQLObjectInfoRetriever());
+        this.fieldSearchAlgorithm = null;
     }
 
     @Reference(target = "(type=method)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -153,7 +149,7 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
-        this.methodSearchAlgorithm = new BreadthFirstSearch(new GraphQLObjectInfoRetriever());
+        this.methodSearchAlgorithm = null;
     }
 
     @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
@@ -162,6 +158,6 @@ public class GraphQLTypeRetriever {
     }
 
     public void unsetExtensionsHandler(GraphQLExtensionsHandler extensionsHandler) {
-        this.extensionsHandler = new GraphQLExtensionsHandler();
+        this.extensionsHandler = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
@@ -22,10 +22,7 @@ import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
 import graphql.annotations.processor.typeBuilders.*;
 import graphql.schema.*;
-import org.osgi.service.component.annotations.Component;
-import org.osgi.service.component.annotations.Reference;
-import org.osgi.service.component.annotations.ReferencePolicy;
-import org.osgi.service.component.annotations.ReferencePolicyOption;
+import org.osgi.service.component.annotations.*;
 
 import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
 
@@ -107,7 +104,7 @@ public class GraphQLTypeRetriever {
         return graphQLFieldRetriever;
     }
 
-    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
     }
@@ -116,7 +113,7 @@ public class GraphQLTypeRetriever {
         this.graphQLObjectInfoRetriever = null;
     }
 
-    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setGraphQLInterfaceRetriever(GraphQLInterfaceRetriever graphQLInterfaceRetriever) {
         this.graphQLInterfaceRetriever = graphQLInterfaceRetriever;
     }
@@ -125,7 +122,7 @@ public class GraphQLTypeRetriever {
         this.graphQLInterfaceRetriever = null;
     }
 
-    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setGraphQLFieldRetriever(GraphQLFieldRetriever graphQLFieldRetriever) {
         this.graphQLFieldRetriever = graphQLFieldRetriever;
     }
@@ -134,7 +131,7 @@ public class GraphQLTypeRetriever {
         this.graphQLFieldRetriever = null;
     }
 
-    @Reference(target = "(type=field)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, target = "(type=field)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
         this.fieldSearchAlgorithm = fieldSearchAlgorithm;
     }
@@ -143,7 +140,7 @@ public class GraphQLTypeRetriever {
         this.fieldSearchAlgorithm = null;
     }
 
-    @Reference(target = "(type=method)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, target = "(type=method)", policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
         this.methodSearchAlgorithm = methodSearchAlgorithm;
     }
@@ -152,7 +149,7 @@ public class GraphQLTypeRetriever {
         this.methodSearchAlgorithm = null;
     }
 
-    @Reference(policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    @Reference(cardinality = ReferenceCardinality.OPTIONAL, policy=ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
     public void setExtensionsHandler(GraphQLExtensionsHandler extensionsHandler) {
         this.extensionsHandler = extensionsHandler;
     }

--- a/src/main/java/graphql/annotations/processor/searchAlgorithms/BreadthFirstSearch.java
+++ b/src/main/java/graphql/annotations/processor/searchAlgorithms/BreadthFirstSearch.java
@@ -16,6 +16,10 @@ package graphql.annotations.processor.searchAlgorithms;
 
 import graphql.annotations.processor.exceptions.CannotCastMemberException;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import java.lang.reflect.Member;
 import java.lang.reflect.Method;
@@ -23,9 +27,13 @@ import java.util.LinkedList;
 import java.util.List;
 
 
+@Component(service = SearchAlgorithm.class, property = "type=method", immediate = true)
 public class BreadthFirstSearch implements SearchAlgorithm {
 
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
+
+    public BreadthFirstSearch() {
+    }
 
     public BreadthFirstSearch(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
@@ -75,5 +83,14 @@ public class BreadthFirstSearch implements SearchAlgorithm {
         else {
             return (Method)member;
         }
+    }
+
+    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    }
+
+    public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
     }
 }

--- a/src/main/java/graphql/annotations/processor/searchAlgorithms/BreadthFirstSearch.java
+++ b/src/main/java/graphql/annotations/processor/searchAlgorithms/BreadthFirstSearch.java
@@ -91,6 +91,6 @@ public class BreadthFirstSearch implements SearchAlgorithm {
     }
 
     public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
-        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+        this.graphQLObjectInfoRetriever = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/searchAlgorithms/ParentalSearch.java
+++ b/src/main/java/graphql/annotations/processor/searchAlgorithms/ParentalSearch.java
@@ -16,13 +16,21 @@ package graphql.annotations.processor.searchAlgorithms;
 
 import graphql.annotations.processor.exceptions.CannotCastMemberException;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.osgi.service.component.annotations.ReferencePolicy;
+import org.osgi.service.component.annotations.ReferencePolicyOption;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Member;
 
 
+@Component(service = SearchAlgorithm.class, property = "type=field", immediate = true)
 public class ParentalSearch implements SearchAlgorithm {
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
+
+    public ParentalSearch() {
+    }
 
     public ParentalSearch(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
@@ -56,5 +64,14 @@ public class ParentalSearch implements SearchAlgorithm {
             return (Field) member;
         }
 
+    }
+
+    @Reference(policy= ReferencePolicy.DYNAMIC, policyOption= ReferencePolicyOption.GREEDY)
+    public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    }
+
+    public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
     }
 }

--- a/src/main/java/graphql/annotations/processor/searchAlgorithms/ParentalSearch.java
+++ b/src/main/java/graphql/annotations/processor/searchAlgorithms/ParentalSearch.java
@@ -72,6 +72,6 @@ public class ParentalSearch implements SearchAlgorithm {
     }
 
     public void unsetGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
-        this.graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+        this.graphQLObjectInfoRetriever = null;
     }
 }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
@@ -21,6 +21,7 @@ import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
+import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
 import graphql.schema.GraphQLInputObjectField;
 import graphql.schema.GraphQLInputObjectType;
 
@@ -35,15 +36,15 @@ import static graphql.annotations.processor.util.ObjectUtil.getAllFields;
 
 public class InputObjectBuilder {
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
-    private BreadthFirstSearch breadthFirstSearch;
-    private ParentalSearch parentalSearch;
+    private SearchAlgorithm fieldSearchAlgorithm;
+    private SearchAlgorithm methodSearchAlgorithm;
     private GraphQLFieldRetriever graphQLFieldRetriever;
 
-    public InputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, ParentalSearch parentalSearch, BreadthFirstSearch breadthFirstSearch, GraphQLFieldRetriever graphQLFieldRetriever) {
+    public InputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm methodSearchAlgorithm, SearchAlgorithm fieldSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
-        this.breadthFirstSearch=breadthFirstSearch;
-        this.parentalSearch=parentalSearch;
-        this.graphQLFieldRetriever=graphQLFieldRetriever;
+        this.methodSearchAlgorithm = methodSearchAlgorithm;
+        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
+        this.graphQLFieldRetriever = graphQLFieldRetriever;
     }
 
     /**
@@ -69,7 +70,7 @@ public class InputObjectBuilder {
             if (method.isBridge() || method.isSynthetic()) {
                 continue;
             }
-            if (breadthFirstSearch.isFound(method)) {
+            if (methodSearchAlgorithm.isFound(method)) {
                 GraphQLInputObjectField gqlField = graphQLFieldRetriever.getInputField(method,container);
                 definedFields.add(gqlField.getName());
                 builder.field(gqlField);
@@ -80,7 +81,7 @@ public class InputObjectBuilder {
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            if (parentalSearch.isFound(field)) {
+            if (fieldSearchAlgorithm.isFound(field)) {
                 GraphQLInputObjectField gqlField = graphQLFieldRetriever.getInputField(field,container);
                 definedFields.add(gqlField.getName());
                 builder.field(gqlField);

--- a/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
@@ -40,7 +40,7 @@ public class InputObjectBuilder {
     private SearchAlgorithm methodSearchAlgorithm;
     private GraphQLFieldRetriever graphQLFieldRetriever;
 
-    public InputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm methodSearchAlgorithm, SearchAlgorithm fieldSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever) {
+    public InputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm fieldSearchAlgorithm, SearchAlgorithm methodSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
         this.methodSearchAlgorithm = methodSearchAlgorithm;
         this.fieldSearchAlgorithm = fieldSearchAlgorithm;

--- a/src/main/java/graphql/annotations/processor/typeBuilders/InterfaceBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/InterfaceBuilder.java
@@ -19,6 +19,7 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLTypeResolver;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
+import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.exceptions.CannotCastMemberException;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
@@ -50,11 +51,14 @@ public class InterfaceBuilder {
 
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
     private GraphQLFieldRetriever graphQLFieldRetriever;
+    private GraphQLExtensionsHandler extensionsHandler;
 
-    public InterfaceBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever,GraphQLFieldRetriever graphQLFieldRetriever) {
+    public InterfaceBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, GraphQLFieldRetriever graphQLFieldRetriever, GraphQLExtensionsHandler extensionsHandler) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
         this.graphQLFieldRetriever=graphQLFieldRetriever;
+        this.extensionsHandler = extensionsHandler;
     }
+
     public GraphQLInterfaceType.Builder getInterfaceBuilder(Class<?> iface, ProcessingElementsContainer container) throws GraphQLAnnotationsException,
             IllegalArgumentException, CannotCastMemberException {
         if (!iface.isInterface()) {
@@ -77,7 +81,7 @@ public class InterfaceBuilder {
                 builder.field(gqlField);
             }
         }
-        builder.fields(graphQLFieldRetriever.getExtensionFields(iface, definedFields,container));
+        builder.fields(extensionsHandler.getExtensionFields(iface, definedFields,container));
 
         GraphQLTypeResolver typeResolver = iface.getAnnotation(GraphQLTypeResolver.class);
         builder.typeResolver(newInstance(typeResolver.value()));

--- a/src/main/java/graphql/annotations/processor/typeBuilders/OutputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/OutputObjectBuilder.java
@@ -18,11 +18,11 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLTypeResolver;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
+import graphql.annotations.processor.retrievers.GraphQLExtensionsHandler;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
 import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
-import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
-import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
+import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
@@ -40,17 +40,19 @@ import static graphql.schema.GraphQLObjectType.newObject;
 
 public class OutputObjectBuilder {
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
-    private BreadthFirstSearch breadthFirstSearch;
-    private ParentalSearch parentalSearch;
+    private SearchAlgorithm methodSearchAlgorithm;
+    private SearchAlgorithm fieldSearchAlgorithm;
     private GraphQLFieldRetriever graphQLFieldRetriever;
     private GraphQLInterfaceRetriever graphQLInterfaceRetriever;
+    private GraphQLExtensionsHandler extensionsHandler;
 
-    public OutputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, ParentalSearch parentalSearch, BreadthFirstSearch breadthFirstSearch, GraphQLFieldRetriever graphQLFieldRetriever, GraphQLInterfaceRetriever graphQLInterfaceRetriever) {
+    public OutputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm methodSearchAlgorithm, SearchAlgorithm fieldSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever, GraphQLInterfaceRetriever graphQLInterfaceRetriever, GraphQLExtensionsHandler extensionsHandler) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
-        this.breadthFirstSearch=breadthFirstSearch;
-        this.parentalSearch=parentalSearch;
-        this.graphQLFieldRetriever=graphQLFieldRetriever;
-        this.graphQLInterfaceRetriever=graphQLInterfaceRetriever;
+        this.methodSearchAlgorithm = methodSearchAlgorithm;
+        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
+        this.graphQLFieldRetriever = graphQLFieldRetriever;
+        this.graphQLInterfaceRetriever = graphQLInterfaceRetriever;
+        this.extensionsHandler = extensionsHandler;
     }
 
     /**
@@ -74,7 +76,7 @@ public class OutputObjectBuilder {
             if (method.isBridge() || method.isSynthetic()) {
                 continue;
             }
-            if (breadthFirstSearch.isFound(method)) {
+            if (methodSearchAlgorithm.isFound(method)) {
                 GraphQLFieldDefinition gqlField = graphQLFieldRetriever.getField(method,container);
                 definedFields.add(gqlField.getName());
                 builder.field(gqlField);
@@ -85,7 +87,7 @@ public class OutputObjectBuilder {
             if (Modifier.isStatic(field.getModifiers())) {
                 continue;
             }
-            if (parentalSearch.isFound(field)) {
+            if (fieldSearchAlgorithm.isFound(field)) {
                 GraphQLFieldDefinition gqlField = graphQLFieldRetriever.getField(field,container);
                 definedFields.add(gqlField.getName());
                 builder.field(gqlField);
@@ -98,13 +100,13 @@ public class OutputObjectBuilder {
                 if (container.getProcessing().contains(ifaceName)) {
                     builder.withInterface(new GraphQLTypeReference(ifaceName));
                 } else {
-                    builder.withInterface((GraphQLInterfaceType) graphQLInterfaceRetriever.getInterface(iface,container));
+                    builder.withInterface((GraphQLInterfaceType) graphQLInterfaceRetriever.getInterface(iface, container));
                 }
-                builder.fields(graphQLFieldRetriever.getExtensionFields(iface, definedFields,container));
+                builder.fields(extensionsHandler.getExtensionFields(iface, definedFields, container));
             }
         }
 
-        builder.fields(graphQLFieldRetriever.getExtensionFields(object, definedFields,container));
+        builder.fields(extensionsHandler.getExtensionFields(object, definedFields, container));
 
         return builder;
     }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/OutputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/OutputObjectBuilder.java
@@ -46,7 +46,7 @@ public class OutputObjectBuilder {
     private GraphQLInterfaceRetriever graphQLInterfaceRetriever;
     private GraphQLExtensionsHandler extensionsHandler;
 
-    public OutputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm methodSearchAlgorithm, SearchAlgorithm fieldSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever, GraphQLInterfaceRetriever graphQLInterfaceRetriever, GraphQLExtensionsHandler extensionsHandler) {
+    public OutputObjectBuilder(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever, SearchAlgorithm fieldSearchAlgorithm, SearchAlgorithm methodSearchAlgorithm, GraphQLFieldRetriever graphQLFieldRetriever, GraphQLInterfaceRetriever graphQLInterfaceRetriever, GraphQLExtensionsHandler extensionsHandler) {
         this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
         this.methodSearchAlgorithm = methodSearchAlgorithm;
         this.fieldSearchAlgorithm = fieldSearchAlgorithm;

--- a/src/main/java/graphql/annotations/processor/typeFunctions/ObjectFunction.java
+++ b/src/main/java/graphql/annotations/processor/typeFunctions/ObjectFunction.java
@@ -15,9 +15,9 @@
 package graphql.annotations.processor.typeFunctions;
 
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor;
 import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
-import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.schema.GraphQLType;
 
 import java.lang.reflect.AnnotatedType;
@@ -25,14 +25,14 @@ import java.lang.reflect.AnnotatedType;
 import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
 
-class ObjectFunction implements TypeFunction {
+public class ObjectFunction implements TypeFunction {
 
-    GraphQLInputProcessor graphQLInputProcessor;
-    GraphQLOutputProcessor graphQLOutputProcessor;
+    private GraphQLInputProcessor graphQLInputProcessor;
+    private GraphQLOutputProcessor graphQLOutputProcessor;
 
-    public ObjectFunction(GraphQLInputProcessor graphQLInputProcessor,GraphQLOutputProcessor graphQLOutputProcessor) {
+    public ObjectFunction(GraphQLInputProcessor graphQLInputProcessor, GraphQLOutputProcessor graphQLOutputProcessor) {
         this.graphQLInputProcessor = graphQLInputProcessor;
-        this.graphQLOutputProcessor=graphQLOutputProcessor;
+        this.graphQLOutputProcessor = graphQLOutputProcessor;
     }
 
 
@@ -52,7 +52,7 @@ class ObjectFunction implements TypeFunction {
         if (inputType) {
             return graphQLInputProcessor.getInputTypeOrRef(aClass, container);
         } else {
-            return graphQLOutputProcessor.getOutputTypeOrRef(aClass,container);
+            return graphQLOutputProcessor.getOutputTypeOrRef(aClass, container);
         }
     }
 

--- a/src/main/java/graphql/annotations/processor/typeFunctions/TypeFunction.java
+++ b/src/main/java/graphql/annotations/processor/typeFunctions/TypeFunction.java
@@ -59,6 +59,7 @@ public interface TypeFunction {
      * @param input is InputType
      * @param aClass The java type to build the type name for
      * @param annotatedType The {@link AnnotatedType} of the java type, which may be a {link AnnotatedParameterizedType}
+     * @param container a class that hold several members that are required in order to build schema
      * @return The built {@link GraphQLType}
      */
 

--- a/src/main/java/graphql/annotations/processor/util/DataFetcherConstructor.java
+++ b/src/main/java/graphql/annotations/processor/util/DataFetcherConstructor.java
@@ -17,6 +17,7 @@ package graphql.annotations.processor.util;
 import graphql.annotations.annotationTypes.GraphQLDataFetcher;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.schema.DataFetcher;
+import org.osgi.service.component.annotations.Component;
 
 import java.lang.reflect.Constructor;
 import java.util.stream.Stream;
@@ -25,6 +26,7 @@ import static graphql.annotations.processor.util.ReflectionKit.constructNewInsta
 import static graphql.annotations.processor.util.ReflectionKit.newInstance;
 import static java.util.Arrays.stream;
 
+@Component(service = DataFetcherConstructor.class)
 public class DataFetcherConstructor {
     public DataFetcher constructDataFetcher(String fieldName, GraphQLDataFetcher annotatedDataFetcher) {
         final String[] args;

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -98,7 +98,6 @@ public class GraphQLExtensionsTest {
         instance.registerTypeExtension(TestObjectExtension.class);
         GraphQLObjectHandler graphQLObjectHandler = new GraphQLObjectHandler();
         GraphQLObjectType object = graphQLObjectHandler.getObject(GraphQLExtensionsTest.TestObject.class, instance.getContainer());
-        instance.unregisterTypeExtension(TestObjectExtension.class);
 
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 5);
@@ -118,7 +117,6 @@ public class GraphQLExtensionsTest {
         instance.registerTypeExtension(TestObjectExtension.class);
         GraphQLObjectHandler graphQLObjectHandler = new GraphQLObjectHandler();
         GraphQLObjectType object = graphQLObjectHandler.getObject(GraphQLExtensionsTest.TestObject.class, instance.getContainer());
-        instance.unregisterTypeExtension(TestObjectExtension.class);
 
         GraphQLSchema schema = newSchema().query(object).build();
         GraphQLSchema schemaInherited = newSchema().query(object).build();
@@ -139,6 +137,5 @@ public class GraphQLExtensionsTest {
         instance.registerTypeExtension(TestObjectExtensionInvalid.class);
         GraphQLAnnotationsException e = expectThrows(GraphQLAnnotationsException.class, () -> graphQLObjectHandler.getObject(TestObject.class,instance.getContainer()));
         assertTrue(e.getMessage().startsWith("Duplicate field"));
-        instance.unregisterTypeExtension(TestObjectExtensionInvalid.class);
     }
 }

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -96,7 +96,7 @@ public class GraphQLExtensionsTest {
     public void fields() {
         GraphQLAnnotations instance = new GraphQLAnnotations();
         instance.registerTypeExtension(TestObjectExtension.class);
-        GraphQLObjectHandler graphQLObjectHandler = new GraphQLObjectHandler();
+        GraphQLObjectHandler graphQLObjectHandler = instance.getObjectHandler();
         GraphQLObjectType object = graphQLObjectHandler.getObject(GraphQLExtensionsTest.TestObject.class, instance.getContainer());
 
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
@@ -115,7 +115,7 @@ public class GraphQLExtensionsTest {
     public void values() {
         GraphQLAnnotations instance = new GraphQLAnnotations();
         instance.registerTypeExtension(TestObjectExtension.class);
-        GraphQLObjectHandler graphQLObjectHandler = new GraphQLObjectHandler();
+        GraphQLObjectHandler graphQLObjectHandler = instance.getObjectHandler();
         GraphQLObjectType object = graphQLObjectHandler.getObject(GraphQLExtensionsTest.TestObject.class, instance.getContainer());
 
         GraphQLSchema schema = newSchema().query(object).build();
@@ -133,7 +133,7 @@ public class GraphQLExtensionsTest {
     @Test
     public void testDuplicateField() {
         GraphQLAnnotations instance = new GraphQLAnnotations();
-        GraphQLObjectHandler graphQLObjectHandler = new GraphQLObjectHandler();
+        GraphQLObjectHandler graphQLObjectHandler = instance.getObjectHandler();
         instance.registerTypeExtension(TestObjectExtensionInvalid.class);
         GraphQLAnnotationsException e = expectThrows(GraphQLAnnotationsException.class, () -> graphQLObjectHandler.getObject(TestObject.class,instance.getContainer()));
         assertTrue(e.getMessage().startsWith("Duplicate field"));

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -54,7 +54,7 @@ public class GraphQLFragmentTest {
     public void testInterfaceInlineFragment() throws Exception {
         // Given
         registry = new HashMap<>();
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=new GraphQLInterfaceRetriever();
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
 
 
         GraphQLObjectType rootType = GraphQLAnnotations.object(RootObject.class);

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -59,7 +59,7 @@ public class GraphQLInterfaceTest {
 
     @Test
     public void noResolver() {
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=new GraphQLInterfaceRetriever();
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
 
         GraphQLObjectType object = (GraphQLObjectType) graphQLInterfaceRetriever.getInterface(NoResolverIface.class,GraphQLAnnotations.getInstance().getContainer());
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
@@ -114,8 +114,7 @@ public class GraphQLInterfaceTest {
 
     @Test
     public void test() {
-
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=new GraphQLInterfaceRetriever();
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
         GraphQLInterfaceType iface = (GraphQLInterfaceType) graphQLInterfaceRetriever.getInterface(TestIface.class,GraphQLAnnotations.getInstance().getContainer());
         List<GraphQLFieldDefinition> fields = iface.getFieldDefinitions();
         assertEquals(fields.size(), 1);
@@ -124,7 +123,7 @@ public class GraphQLInterfaceTest {
 
     @Test
     public void testUnion() {
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=new GraphQLInterfaceRetriever();
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
         GraphQLUnionType unionType = (GraphQLUnionType) graphQLInterfaceRetriever.getInterface(TestUnion.class,GraphQLAnnotations.getInstance().getContainer());
         assertEquals(unionType.getTypes().size(), 1);
         assertEquals(unionType.getTypes().get(0).getName(), "TestObject1");

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -544,7 +544,7 @@ public class GraphQLObjectTest {
     @Test
     public void recursiveTypes() {
         GraphQLAnnotations graphQLAnnotations = new GraphQLAnnotations();
-        GraphQLObjectType object = new GraphQLObjectHandler().getObject(Class1.class,graphQLAnnotations.getContainer());
+        GraphQLObjectType object = graphQLAnnotations.getObjectHandler().getObject(Class1.class,graphQLAnnotations.getContainer());
         GraphQLSchema schema = newSchema().query(object).build();
 
         Class1 class1 = new Class1();

--- a/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
+++ b/src/test/java/graphql/annotations/GraphQLSimpleSchemaTest.java
@@ -74,7 +74,7 @@ public class GraphQLSimpleSchemaTest {
     @Test
     public void detachedCall() {
         GraphQLAnnotations graphQLAnnotations = new GraphQLAnnotations();
-        GraphQLObjectHandler graphQLObjectHandler=new GraphQLObjectHandler();
+        GraphQLObjectHandler graphQLObjectHandler = graphQLAnnotations.getObjectHandler();
         GraphQLObjectType queryObject = graphQLObjectHandler.getObject(Query.class,graphQLAnnotations.getContainer());
         GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
@@ -86,7 +86,7 @@ public class GraphQLSimpleSchemaTest {
     @Test
     public void staticCall() {
         GraphQLAnnotations graphQLAnnotations = new GraphQLAnnotations();
-        GraphQLObjectHandler graphQLObjectHandler=new GraphQLObjectHandler();
+        GraphQLObjectHandler graphQLObjectHandler = graphQLAnnotations.getObjectHandler();
         GraphQLObjectType queryObject = graphQLObjectHandler.getObject(Query.class,graphQLAnnotations.getContainer());
         GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 

--- a/src/test/java/graphql/annotations/processor/typeFunctions/DefaultTypeFunctionTestHelper.java
+++ b/src/test/java/graphql/annotations/processor/typeFunctions/DefaultTypeFunctionTestHelper.java
@@ -21,9 +21,7 @@ import graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor;
 public class DefaultTypeFunctionTestHelper {
     public static DefaultTypeFunction testedDefaultTypeFunction() {
         // wire up the ability
-        GraphQLAnnotations graphQLAnnotations = new GraphQLAnnotations();
         DefaultTypeFunction defaultTypeFunction = new DefaultTypeFunction(new GraphQLInputProcessor(),new GraphQLOutputProcessor());
-        defaultTypeFunction.setAnnotationsProcessor(graphQLAnnotations);
         return defaultTypeFunction;
     }
 }


### PR DESCRIPTION
Hi,

Since the last refactoring OSGi usage was broken, so I created a new OSGi entry point, GraphQLAnnotationsComponent, that can be used to access the different processors (mainly outputTypeProcessor, on which we can use getOutputType). This leaves the normal non-OSGi usage in GraphQLAnnotations class.

Additionnaly, I introduced OSGi annotations on different classes, so that each part can be overridden if needed. The following classes are now loaded as components in OSGi container :

```
34 | ACTIVE | graphql.annotations.processor.GraphQLAnnotationsComponent
35 | ACTIVE | graphql.annotations.processor.graphQLProcessors.GraphQLInputProcessor
36 | ACTIVE | graphql.annotations.processor.graphQLProcessors.GraphQLOutputProcessor
37 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLExtensionsHandler
38 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLFieldRetriever
39 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLInputObjectRetriever
40 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever
41 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLObjectHandler
42 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever
43 | ACTIVE | graphql.annotations.processor.retrievers.GraphQLOutputObjectRetriever
44 | ACTIVE | graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch
45 | ACTIVE | graphql.annotations.processor.searchAlgorithms.ParentalSearch
46 | ACTIVE | graphql.annotations.processor.typeFunctions.DefaultTypeFunction
47 | ACTIVE | graphql.annotations.processor.util.DataFetcherConstructor
```

The main changes are additionnal OSGi declarative services annotations and associated setters to do the wiring.

I moved some code that was dispatched in GraphQLAnnotations and GraphQLFieldRetriever handling the extensions in a dedicated class, GraphQLExtensionsHandler , that is available in GraphQLAnnotationsComponent . I also removed the "unregister*" functions as they had no equivalents for type registry and are not very useful anymore now that we have a separate ProcessingElementsContainer. They  can still be easily cleaned by accessing the maps in ProcessingElementsContainer.
