### PR TITLE
Allows to defines a getInstance() method on TypeResolver/DataFetcher/…

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,17 +34,25 @@ GraphQLObjectType object = GraphQLAnnotations.object(SomeObject.class);
 
 ## Defining Interfaces
 
-This is very similar to defining objects:
+This is very similar to defining objects, with the addition of type resolver : 
 
 ```java
+@GraphQLTypeResolver(MyTypeResolver.class)
 public interface SomeInterface {
   @GraphQLField
   String field();
 }
 
+public class MyTypeResolver implements TypeResolver {
+  GraphQLObjectType getType(TypeResolutionEnvironment env) { ... }
+}
+
 // ...
 GraphQLInterfaceType object = GraphQLAnnotations.iface(SomeInterface.class);
 ```
+
+An instance of the type resolver will be created from the specified class. If a `getInstance` method is present on the
+class, it will be used instead of the default constructor.
 
 ## Fields
 
@@ -108,10 +116,21 @@ public String field(@GraphQLDefaultValue(DefaultValue.class) String value) {
 }
 ```
 
+The `DefaultValue` class can define a `getInstance` method that will be called instead of the default constructor.
+
 `@GraphQLDeprecate` and Java's `@Deprecated` can be used to specify a deprecated
 field.
 
-You can specify a custom data fetcher for a field with `@GraphQLDataFetcher`
+### Custom data fetcher
+
+You can specify a custom data fetcher for a field with `@GraphQLDataFetcher`. The annotation will reference a class name, 
+which will be used as data fetcher. 
+
+An instance of the data fetcher will be created. The `args` attribute on the annotation can be used to specify a list of 
+String arguments to pass to the construcor, allowing to reuse the same class on different fields, with different parameter. 
+The `firstArgIsTargetName` attribute can also be set on `@GraphQLDataFetcher` to pass the field name as a single parameter of the constructor.
+
+If no argument is needed and a `getInstance` method is present, this method will be called instead of the constructor.
 
 ## Type extensions
 

--- a/src/main/java/graphql/annotations/processor/util/ReflectionKit.java
+++ b/src/main/java/graphql/annotations/processor/util/ReflectionKit.java
@@ -18,6 +18,8 @@ import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 
 /**
  * A package level helper in calling reflective methods and turning them into
@@ -26,8 +28,16 @@ import java.lang.reflect.InvocationTargetException;
 public class ReflectionKit {
     public static <T> T newInstance(Class<T> clazz) throws GraphQLAnnotationsException {
         try {
+            try {
+                Method getInstance = clazz.getMethod("getInstance", new Class<?>[0]);
+                if (Modifier.isStatic(getInstance.getModifiers()) && clazz.isAssignableFrom(getInstance.getReturnType())) {
+                    return (T) getInstance.invoke(null);
+                }
+            } catch (NoSuchMethodException e) {
+                // ignore, just call the constructor
+            }
             return clazz.newInstance();
-        } catch (InstantiationException | IllegalAccessException e) {
+        } catch (InstantiationException | InvocationTargetException | IllegalAccessException e) {
             throw new GraphQLAnnotationsException("Unable to instantiate class : " + clazz, e);
         }
     }

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -69,6 +69,10 @@ public class GraphQLInterfaceTest {
 
     public static class Resolver implements TypeResolver {
 
+        public static Resolver getInstance() {
+            return new Resolver();
+        }
+
         @Override
         public GraphQLObjectType getType(TypeResolutionEnvironment env) {
             try {


### PR DESCRIPTION
…Validators/DefaultValues..

Small improvement (last one !) : when calling newInstance(), it first checks if a getInstance() returning a singleton is available and call it if possible. This is very useful for TypeResolver, which I need to instantiate on my side (to correctly fill the available types), and share the same instance with graphql-java (otherwise, I need to use ugly static maps of types). It's also available and can be useful for all types which are created using this method.
