### PR TITLE
Fix union

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ public class PetTypeResolver implements TypeResolver {
     }
 }
 ```
+NOTE: you can have (but not mandatory) a type resolver with constructor that has `Class<?>[]` as the first parameter and
+`ProcessingElementsContainer` as the second. the `Class<?>[]` parameter contains the possibleTypes class
+and `ProcessingElementsContainer` has all sorts of utils (you can check `UnionTypeResolver` to see how we use it there)
+
 ## Fields
 
 In addition to specifying a field over a Java class field, a field can be defined over a method:

--- a/README.md
+++ b/README.md
@@ -59,15 +59,14 @@ class, it will be used instead of the default constructor.
 To have a union, you must annotate an interface with `@GraphQLUnion`. In the annotation, you must declare all the 
 possible types of the union, and a type resolver.
 If no type resolver is specified, `UnionTypeResovler` is used. It follows this algorithm:
-The resolver assumes the the DB entity's name contains the API entity's name, after removing the "Api"
-suffix from the name of the API entity. If so, it takes the result from the dataFetcher and decides to which
+The resolver assumes the the DB entity's name is the same as  the API entity's name.
+ If so, it takes the result from the dataFetcher and decides to which
 API entity it should be mapped (according to the name). 
-Example: If you have a `Pet` union type, and the dataFetcher returns `DogDB` (or just `Dog`), the typeResolver
-will check for each API entity if its name (without the "Api" suffix - if the suffix exists) is contained 
-inside the name of the DB entity, so both `Dog` and `DogApi` are valid.
+Example: If you have a `Pet` union type, and the dataFetcher returns `Dog`, the typeResolver
+will check for each API entity if its name is equal to `Dog`, and returns if it finds something
 
 ```java
-@GraphQLUnion(possibleTypes={DogApi.class, Cat.class})
+@GraphQLUnion(possibleTypes={Dog.class, Cat.class})
 public interface Pet {}
 ``` 
 and an example with custom `TypeResovler`:

--- a/build.gradle
+++ b/build.gradle
@@ -78,6 +78,7 @@ dependencies {
     compileOnly 'biz.aQute.bnd:biz.aQute.bndlib:3.2.0'
 
     testCompile 'org.testng:testng:6.9.10'
+    testCompile 'org.hamcrest:hamcrest-all:1.3'
 }
 
 test.useTestNG()

--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
@@ -14,6 +14,9 @@
  */
 package graphql.annotations.annotationTypes;
 
+import graphql.annotations.typeResolvers.UnionTypeResolver;
+import graphql.schema.TypeResolver;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -23,4 +26,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLUnion {
     Class<?>[] possibleTypes();
+
+    Class<? extends TypeResolver> typeResolver() default UnionTypeResolver.class;
 }

--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLUnion {
-    Class<?>[] possibleTypes() default {};
+    Class<?>[] possibleTypes();
 
     Class<? extends TypeResolver> typeResolver() default UnionTypeResolver.class;
 }

--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLUnion.java
@@ -25,7 +25,7 @@ import java.lang.annotation.Target;
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface GraphQLUnion {
-    Class<?>[] possibleTypes();
+    Class<?>[] possibleTypes() default {};
 
     Class<? extends TypeResolver> typeResolver() default UnionTypeResolver.class;
 }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
@@ -85,13 +85,17 @@ public class UnionBuilder {
 
     private TypeResolver getTypeResolver(ProcessingElementsContainer container, GraphQLUnion unionAnnotation) {
         Optional<Constructor<?>> typeResolverConstructorOptional = Arrays.stream(unionAnnotation.typeResolver().getConstructors())
-                .filter(constructor -> constructor.getParameterCount() == 2 &&
-                        container.getClass().isAssignableFrom(constructor.getParameterTypes()[1]) &&
-                        Class[].class.isAssignableFrom(constructor.getParameterTypes()[0]))
+                .filter(constructor -> constructor.getParameterCount() == 0 || constructorHasPossibleTypesAndContainerAsParameters(container, constructor))
                 .findFirst();
 
         return typeResolverConstructorOptional
                 .map(constructor -> (TypeResolver) constructNewInstance(constructor, unionAnnotation.possibleTypes(), container))
                 .orElseGet(() -> new UnionTypeResolver(unionAnnotation.possibleTypes(), container));
+    }
+
+    private boolean constructorHasPossibleTypesAndContainerAsParameters(ProcessingElementsContainer container, Constructor<?> constructor) {
+        return constructor.getParameterCount() == 2 &&
+                Class[].class.isAssignableFrom(constructor.getParameterTypes()[0]) &&
+                container.getClass().isAssignableFrom(constructor.getParameterTypes()[1]);
     }
 }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -19,17 +19,20 @@ import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLType;
 import graphql.annotations.annotationTypes.GraphQLUnion;
 import graphql.annotations.processor.ProcessingElementsContainer;
-import graphql.annotations.processor.util.ReflectionKit;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
-import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
+import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.annotations.typeResolvers.UnionTypeResolver;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLUnionType;
+import graphql.schema.TypeResolver;
 
+import java.lang.reflect.Constructor;
 import java.util.Arrays;
-import java.util.function.Function;
+import java.util.Optional;
 
+import static graphql.annotations.processor.util.ReflectionKit.constructNewInstance;
+import static graphql.annotations.processor.util.ReflectionKit.newInstance;
 import static graphql.schema.GraphQLUnionType.newUnionType;
 
 public class UnionBuilder {
@@ -65,21 +68,32 @@ public class UnionBuilder {
         TypeFunction typeFunction = container.getDefaultTypeFunction();
 
         if (typeAnnotation != null) {
-            typeFunction = ReflectionKit.newInstance(typeAnnotation.value());
+            typeFunction = newInstance(typeAnnotation.value());
         }
 
         TypeFunction finalTypeFunction = typeFunction;
-        Arrays.asList(unionAnnotation.possibleTypes()).stream()
-                .map(new Function<Class<?>, graphql.schema.GraphQLType>() {
-                    @Override
-                    public graphql.schema.GraphQLType apply(Class<?> aClass) {
-                        return finalTypeFunction.buildType(aClass, null, container);
-                    }
-                })
+        Arrays.stream(unionAnnotation.possibleTypes())
+                .map(aClass -> finalTypeFunction.buildType(aClass, null, container))
                 .map(v -> (GraphQLObjectType) v)
                 .forEach(builder::possibleType);
 
-        builder.typeResolver(new UnionTypeResolver(unionAnnotation.possibleTypes(), container));
+        TypeResolver typeResolver = getTypeResolver(container, unionAnnotation);
+
+        builder.typeResolver(typeResolver);
         return builder;
+    }
+
+    private TypeResolver getTypeResolver(ProcessingElementsContainer container, GraphQLUnion unionAnnotation) {
+        Optional<Constructor<?>> typeResolverConstructorOptional = Arrays.stream(unionAnnotation.typeResolver().getConstructors())
+                .filter(constructor -> constructor.getParameterCount() == 2 &&
+                        container.getClass().isAssignableFrom(constructor.getParameterTypes()[1]) &&
+                        Class[].class.isAssignableFrom(constructor.getParameterTypes()[0]))
+                .findFirst();
+
+        TypeResolver typeResolver;
+        typeResolver = typeResolverConstructorOptional
+                .map(constructor -> (TypeResolver) constructNewInstance(constructor, unionAnnotation.possibleTypes(), container))
+                .orElseGet(() -> new UnionTypeResolver(unionAnnotation.possibleTypes(), container));
+        return typeResolver;
     }
 }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
@@ -24,7 +24,7 @@ import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.annotations.typeResolvers.UnionTypeResolver;
 import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLUnionType;
+import graphql.schema.GraphQLUnionType.Builder;
 import graphql.schema.TypeResolver;
 
 import java.lang.reflect.Constructor;
@@ -44,18 +44,18 @@ public class UnionBuilder {
     }
 
     /**
-     * This will examine the class and return a {@link GraphQLUnionType.Builder} ready for further definition
+     * This will examine the class and return a {@link Builder} ready for further definition
      * @param container a class that hold several members that are required in order to build schema
      * @param iface interface to examine
-     * @return a {@link GraphQLUnionType.Builder}
+     * @return a {@link Builder}
      * @throws GraphQLAnnotationsException if the class cannot be examined
      */
 
-    public GraphQLUnionType.Builder getUnionBuilder(Class<?> iface, ProcessingElementsContainer container) throws GraphQLAnnotationsException, IllegalArgumentException {
+    public Builder getUnionBuilder(Class<?> iface, ProcessingElementsContainer container) throws GraphQLAnnotationsException, IllegalArgumentException {
         if (!iface.isInterface()) {
             throw new IllegalArgumentException(iface + " is not an interface");
         }
-        GraphQLUnionType.Builder builder = newUnionType();
+        Builder builder = newUnionType();
 
         GraphQLUnion unionAnnotation = iface.getAnnotation(GraphQLUnion.class);
         builder.name(graphQLObjectInfoRetriever.getTypeName(iface));
@@ -90,10 +90,8 @@ public class UnionBuilder {
                         Class[].class.isAssignableFrom(constructor.getParameterTypes()[0]))
                 .findFirst();
 
-        TypeResolver typeResolver;
-        typeResolver = typeResolverConstructorOptional
+        return typeResolverConstructorOptional
                 .map(constructor -> (TypeResolver) constructNewInstance(constructor, unionAnnotation.possibleTypes(), container))
                 .orElseGet(() -> new UnionTypeResolver(unionAnnotation.possibleTypes(), container));
-        return typeResolver;
     }
 }

--- a/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/UnionBuilder.java
@@ -89,7 +89,14 @@ public class UnionBuilder {
                 .findFirst();
 
         return typeResolverConstructorOptional
-                .map(constructor -> (TypeResolver) constructNewInstance(constructor, unionAnnotation.possibleTypes(), container))
+                .map(constructor -> {
+                    if(constructor.getParameterCount() == 0) {
+                        return (TypeResolver) constructNewInstance(constructor);
+                    }
+                    else {
+                        return (TypeResolver) constructNewInstance(constructor, unionAnnotation.possibleTypes(), container);
+                    }
+                })
                 .orElseGet(() -> new UnionTypeResolver(unionAnnotation.possibleTypes(), container));
     }
 

--- a/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
+++ b/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
@@ -39,7 +39,8 @@ public class UnionTypeResolver implements TypeResolver {
         Object object = env.getObject();
         Optional<Entry<Class<?>, GraphQLType>> maybeType = types.entrySet().
                 stream().filter(e -> object.getClass().getSimpleName()
-                .contains(e.getKey().getSimpleName().replace("Api", ""))).findFirst();
+                .equals(e.getKey().getSimpleName())).findFirst();
+
         if (maybeType.isPresent()) {
             return (GraphQLObjectType) maybeType.get().getValue();
         } else {

--- a/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
+++ b/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
@@ -16,16 +16,18 @@ package graphql.annotations.typeResolvers;
 
 import graphql.TypeResolutionEnvironment;
 import graphql.annotations.processor.ProcessingElementsContainer;
-import graphql.schema.*;
+import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLType;
+import graphql.schema.TypeResolver;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Optional;
 
 public class UnionTypeResolver implements TypeResolver {
-    private final Map<Class<?>, graphql.schema.GraphQLType> types = new HashMap<>();
+    private final Map<Class<?>, GraphQLType> types = new HashMap<>();
 
     public UnionTypeResolver(Class<?>[] classes, ProcessingElementsContainer container) {
         Arrays.stream(classes).
@@ -35,7 +37,7 @@ public class UnionTypeResolver implements TypeResolver {
     @Override
     public GraphQLObjectType getType(TypeResolutionEnvironment env) {
         Object object = env.getObject();
-        Optional<Map.Entry<Class<?>, GraphQLType>> maybeType = types.entrySet().
+        Optional<Entry<Class<?>, GraphQLType>> maybeType = types.entrySet().
                 stream().filter(e -> e.getKey().isAssignableFrom(object.getClass())).findFirst();
         if (maybeType.isPresent()) {
             return (GraphQLObjectType) maybeType.get().getValue();

--- a/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
+++ b/src/main/java/graphql/annotations/typeResolvers/UnionTypeResolver.java
@@ -38,7 +38,8 @@ public class UnionTypeResolver implements TypeResolver {
     public GraphQLObjectType getType(TypeResolutionEnvironment env) {
         Object object = env.getObject();
         Optional<Entry<Class<?>, GraphQLType>> maybeType = types.entrySet().
-                stream().filter(e -> e.getKey().isAssignableFrom(object.getClass())).findFirst();
+                stream().filter(e -> object.getClass().getSimpleName()
+                .contains(e.getKey().getSimpleName().replace("Api", ""))).findFirst();
         if (maybeType.isPresent()) {
             return (GraphQLObjectType) maybeType.get().getValue();
         } else {

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -202,7 +202,7 @@ public class GraphQLUnionTest {
         }
     }
 
-    static class PetResolver implements TypeResolver {
+    public static class PetResolver implements TypeResolver {
         @Override
         public GraphQLObjectType getType(TypeResolutionEnvironment env) {
             Object object = env.getObject();

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -86,7 +86,7 @@ public class GraphQLUnionTest {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        String query = "{ hardwareComputer{ ... on Computer {name}, ... on Screen{resolution}} }";
+        String query = "{ getHardwareComputer{ ... on Computer {name}, ... on Screen{resolution}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("hardwareComputer").get("name"), "MyComputer");
@@ -97,7 +97,7 @@ public class GraphQLUnionTest {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        String query = "{ hardwareScreen{ ... on Computer {name}, ... on Screen{resolution}} }";
+        String query = "{ getHardwareScreen{ ... on Computer {name}, ... on Screen{resolution}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("hardwareScreen").get("resolution"), 10);

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -1,0 +1,118 @@
+package graphql.annotations;
+
+import graphql.ExecutionResult;
+import graphql.GraphQL;
+import graphql.annotations.annotationTypes.GraphQLDataFetcher;
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLUnion;
+import graphql.annotations.processor.GraphQLAnnotations;
+import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
+import graphql.annotations.typeResolvers.UnionTypeResolver;
+import graphql.schema.*;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import javax.lang.model.type.UnionType;
+import java.util.List;
+import java.util.Map;
+
+import static graphql.schema.GraphQLSchema.newSchema;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class GraphQLUnionTest {
+
+    @BeforeMethod
+    public void init() {
+        GraphQLAnnotations.getInstance().getTypeRegistry().clear();
+    }
+
+    @Test
+    public void getGraphQLType_typeIsUnion_returnsUnionType() throws Exception {
+        //Arrange
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever = GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
+
+        //Act
+        GraphQLOutputType unionType = graphQLInterfaceRetriever.getInterface(Hardware.class, GraphQLAnnotations.getInstance().getContainer());
+
+        //Assert
+        assertThat(unionType, instanceOf(UnionType.class));
+    }
+
+    @Test
+    public void getResolver_resolverIsDefaultOne_returnsUnionTypeResolver() throws Exception {
+        //Arrange
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever = GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
+
+        //Act
+        GraphQLUnionType unionType = (GraphQLUnionType) graphQLInterfaceRetriever.getInterface(Hardware.class, GraphQLAnnotations.getInstance().getContainer());
+        TypeResolver typeResolver = unionType.getTypeResolver();
+
+        //Assert
+        assertThat(typeResolver, instanceOf(UnionTypeResolver.class));
+    }
+
+    @Test
+    public void unionType_buildSchema_unionIsAFieldOfQuery() throws Exception {
+        //Act
+        GraphQLObjectType object = GraphQLAnnotations.object(Query.class);
+        List<GraphQLFieldDefinition> unions = object.getFieldDefinitions();
+
+        //Assert
+        assertThat(unions.size(), is(1));
+        assertThat(unions.get(0).getName(), is("hardware"));
+    }
+
+    @Test
+    public void query() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ hardware{ ... on Computer {name}} }");
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("hardware").get("name"), "Guy");
+    }
+
+
+    @GraphQLUnion(possibleTypes = {Computer.class, Screen.class})
+    interface Hardware {
+    }
+
+    private static class Screen {
+    }
+
+    // Hibernate class with same structure of API class
+    static class ComputerDB {
+        String name;
+
+        public ComputerDB(String name) {
+            this.name = name;
+        }
+    }
+
+    public static class HardwareFetcher implements DataFetcher<ComputerDB> {
+        ComputerDB computerDB = new ComputerDB("Guy");
+
+        @Override
+        public ComputerDB get(DataFetchingEnvironment environment) {
+            return computerDB;
+        }
+    }
+
+    class Computer implements Hardware {
+        @GraphQLField
+        String name;
+    }
+
+    class Query {
+        @GraphQLField
+        @GraphQLDataFetcher(HardwareFetcher.class)
+        public Hardware getHardware() {
+            return null;
+        }
+    }
+
+}

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -76,9 +76,7 @@ public class GraphQLUnionTest {
         List<GraphQLFieldDefinition> unions = object.getFieldDefinitions();
 
         //Assert
-        assertThat(unions.size(), is(2));
-        assertThat(unions.get(0).getName(), is("hardwareComputer"));
-        assertThat(unions.get(1).getName(), is("hardwareScreen"));
+        assertThat(unions.size(), is(3));
     }
 
     @Test
@@ -89,7 +87,7 @@ public class GraphQLUnionTest {
         String query = "{ getHardwareComputer{ ... on Computer {name}, ... on Screen{resolution}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
-        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("hardwareComputer").get("name"), "MyComputer");
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("getHardwareComputer").get("name"), "MyComputer");
     }
 
     @Test
@@ -100,7 +98,7 @@ public class GraphQLUnionTest {
         String query = "{ getHardwareScreen{ ... on Computer {name}, ... on Screen{resolution}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
-        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("hardwareScreen").get("resolution"), 10);
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("getHardwareScreen").get("resolution"), 10);
     }
 
     @Test

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations;
 
 import graphql.ExecutionResult;

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -30,9 +30,9 @@ import java.util.List;
 import java.util.Map;
 
 import static graphql.schema.GraphQLSchema.newSchema;
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.is;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
@@ -107,6 +107,9 @@ public class GraphQLUnionTest {
         @GraphQLField
         int resolution;
 
+        public Screen(int resolution) {
+            this.resolution = resolution;
+        }
     }
 
     @GraphQLUnion(possibleTypes = {Computer.class, Screen.class})
@@ -114,37 +117,21 @@ public class GraphQLUnionTest {
     }
 
     // Hibernate class with same structure of API class
-    public static class ComputerFetcher implements DataFetcher<ComputerDB> {
-        ComputerDB computerDB = new ComputerDB("MyComputer");
+    public static class ComputerFetcher implements DataFetcher<Computer> {
+        Computer computerDB = new Computer("MyComputer");
 
         @Override
-        public ComputerDB get(DataFetchingEnvironment environment) {
+        public Computer get(DataFetchingEnvironment environment) {
             return computerDB;
         }
     }
 
-    public static class ScreenFetcher implements DataFetcher<ScreenDB> {
-        ScreenDB screenDB = new ScreenDB(10);
+    public static class ScreenFetcher implements DataFetcher<Screen> {
+        Screen screenDB = new Screen(10);
 
         @Override
-        public ScreenDB get(DataFetchingEnvironment environment) {
+        public Screen get(DataFetchingEnvironment environment) {
             return screenDB;
-        }
-    }
-
-    static class ComputerDB {
-        String name;
-
-        public ComputerDB(String name) {
-            this.name = name;
-        }
-    }
-
-    static class ScreenDB {
-        int resolution;
-
-        public ScreenDB(int resolution) {
-            this.resolution = resolution;
         }
     }
 
@@ -162,8 +149,12 @@ public class GraphQLUnionTest {
         }
     }
 
-    class Computer implements Hardware {
+    static class Computer implements Hardware {
         @GraphQLField
         String name;
+
+        public Computer(String name) {
+            this.name = name;
+        }
     }
 }

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -26,7 +26,6 @@ import graphql.schema.*;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import javax.lang.model.type.UnionType;
 import java.util.List;
 import java.util.Map;
 
@@ -54,7 +53,7 @@ public class GraphQLUnionTest {
         GraphQLOutputType unionType = graphQLInterfaceRetriever.getInterface(Hardware.class, GraphQLAnnotations.getInstance().getContainer());
 
         //Assert
-        assertThat(unionType, instanceOf(UnionType.class));
+        assertThat(unionType, instanceOf(GraphQLUnionType.class));
     }
 
     @Test
@@ -77,8 +76,9 @@ public class GraphQLUnionTest {
         List<GraphQLFieldDefinition> unions = object.getFieldDefinitions();
 
         //Assert
-        assertThat(unions.size(), is(1));
-        assertThat(unions.get(0).getName(), is("hardware"));
+        assertThat(unions.size(), is(2));
+        assertThat(unions.get(0).getName(), is("hardwareComputer"));
+        assertThat(unions.get(1).getName(), is("hardwareScreen"));
     }
 
     @Test


### PR DESCRIPTION
Now union type can have a `TypeResolver`. I also added a default `TypeResolver` that resolves the type by its name, i.e: The DB and API entities must have similar names, up to "API" suffix in the API entity's name

@yarinvak @tdraier as usual, please CR me