### PR TITLE
Fix interface

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,7 @@ gradle.projectsEvaluated {
 dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
     compile 'com.graphql-java:graphql-java:7.0'
+    compile 'org.clapper:javautil:3.2.0'
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'

--- a/src/main/java/graphql/annotations/processor/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/processor/GraphQLAnnotations.java
@@ -27,8 +27,10 @@ import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.annotations.processor.util.DataFetcherConstructor;
 import graphql.relay.Relay;
 import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLType;
 
 import java.util.Map;
+import java.util.Set;
 
 import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 
@@ -40,6 +42,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
 
     private GraphQLObjectHandler graphQLObjectHandler;
     private GraphQLExtensionsHandler graphQLExtensionsHandler;
+    private GraphQLAdditionalTypesHandler graphQLAdditionalTypesHandler;
 
     private ProcessingElementsContainer container;
 
@@ -73,6 +76,13 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         extensionsHandler.setMethodSearchAlgorithm(methodSearchAlgorithm);
         extensionsHandler.setFieldRetriever(fieldRetriever);
 
+        GraphQLAdditionalTypesHandler additionalTypesHandler = new GraphQLAdditionalTypesHandler();
+        additionalTypesHandler.setGraphQLInterfaceRetriever(interfaceRetriever);
+        additionalTypesHandler.setGraphQLObjectInfoRetriever(objectInfoRetriever);
+        additionalTypesHandler.setMethodSearchAlgorithm(methodSearchAlgorithm);
+        additionalTypesHandler.setFieldSearchAlgorithm(fieldSearchAlgorithm);
+
+        this.graphQLAdditionalTypesHandler = additionalTypesHandler;
         this.graphQLObjectHandler = objectHandler;
         this.graphQLExtensionsHandler = extensionsHandler;
         this.container = new ProcessingElementsContainer(defaultTypeFunction);
@@ -104,6 +114,12 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         return instance.graphQLObjectHandler.getObject(object, instance.getContainer());
     }
 
+    public static Set<GraphQLType> additionalTypes(Class<?> root) {
+        GraphQLAnnotations instance = getInstance();
+        return instance.graphQLAdditionalTypesHandler.getAdditionalInterfacesImplementations(root, instance.getContainer());
+
+    }
+
     public void registerTypeExtension(Class<?> objectClass) {
         graphQLExtensionsHandler.registerTypeExtension(objectClass, container);
     }
@@ -116,7 +132,7 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         getInstance().registerType(typeFunction);
     }
 
-    public Map<String, graphql.schema.GraphQLType> getTypeRegistry() {
+    public Map<String, GraphQLType> getTypeRegistry() {
         return container.getTypeRegistry();
     }
 

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations.processor.retrievers;
 
 import graphql.GraphQLException;

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
@@ -44,13 +44,11 @@ public class GraphQLAdditionalTypesHandler {
     private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
     private SearchAlgorithm methodSearchAlgorithm;
     private SearchAlgorithm fieldSearchAlgorithm;
-    private GraphQLObjectInfoRetriever infoRetriever;
     private ClassFinder classFinder;
 
     public GraphQLAdditionalTypesHandler() {
         classFinder = new ClassFinder();
         classFinder.addClassPath();
-        infoRetriever = new GraphQLObjectInfoRetriever();
     }
 
     public Set<GraphQLType> getAdditionalInterfacesImplementations(Class<?> root, ProcessingElementsContainer container) {
@@ -80,13 +78,13 @@ public class GraphQLAdditionalTypesHandler {
 
     private Set<GraphQLType> getNewImplementations(ProcessingElementsContainer container, ClassFinder classFinder, Class<?> aClass) {
         Set<GraphQLType> additionalFields = new HashSet<>();
-        if (container.getTypeRegistry().containsKey(infoRetriever.getTypeName(aClass)) && aClass.isInterface() && aClass.isAnnotationPresent(GraphQLTypeResolver.class)) {
+        if (container.getTypeRegistry().containsKey(graphQLObjectInfoRetriever.getTypeName(aClass)) && aClass.isInterface() && aClass.isAnnotationPresent(GraphQLTypeResolver.class)) {
             ClassFilter classFilter = new SubclassClassFilter(aClass);
             List<ClassInfo> foundClasses = new ArrayList<>();
             classFinder.findClasses(foundClasses, classFilter);
             for (ClassInfo classInfo : foundClasses) {
                 try {
-                    if (!(container.getTypeRegistry().containsKey(infoRetriever.getTypeName(Class.forName(classInfo.getClassName()))))) {
+                    if (!(container.getTypeRegistry().containsKey(graphQLObjectInfoRetriever.getTypeName(Class.forName(classInfo.getClassName()))))) {
                         GraphQLOutputType additionalObject = graphQLInterfaceRetriever.getInterface(Class.forName(classInfo.getClassName()), container);
                         additionalFields.add(additionalObject);
                     }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
@@ -37,7 +37,7 @@ import java.util.Set;
 import static graphql.annotations.processor.util.ObjectUtil.getAllFields;
 
 @SuppressWarnings("ConstantConditions")
-@Component(service = GraphQLExtensionsHandler.class, immediate = true)
+@Component(service = GraphQLAdditionalTypesHandler.class, immediate = true)
 public class GraphQLAdditionalTypesHandler {
 
     private GraphQLInterfaceRetriever graphQLInterfaceRetriever;

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLAdditionalTypesHandler.java
@@ -1,0 +1,102 @@
+package graphql.annotations.processor.retrievers;
+
+import graphql.GraphQLException;
+import graphql.annotations.annotationTypes.GraphQLTypeResolver;
+import graphql.annotations.processor.ProcessingElementsContainer;
+import graphql.annotations.processor.searchAlgorithms.SearchAlgorithm;
+import graphql.schema.GraphQLOutputType;
+import graphql.schema.GraphQLType;
+import org.clapper.util.classutil.ClassFilter;
+import org.clapper.util.classutil.ClassFinder;
+import org.clapper.util.classutil.ClassInfo;
+import org.clapper.util.classutil.SubclassClassFilter;
+import org.osgi.service.component.annotations.Component;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import static graphql.annotations.processor.util.ObjectUtil.getAllFields;
+
+@SuppressWarnings("ConstantConditions")
+@Component(service = GraphQLExtensionsHandler.class, immediate = true)
+public class GraphQLAdditionalTypesHandler {
+
+    private GraphQLInterfaceRetriever graphQLInterfaceRetriever;
+    private GraphQLObjectInfoRetriever graphQLObjectInfoRetriever;
+    private SearchAlgorithm methodSearchAlgorithm;
+    private SearchAlgorithm fieldSearchAlgorithm;
+    private GraphQLObjectInfoRetriever infoRetriever;
+    private ClassFinder classFinder;
+
+    public GraphQLAdditionalTypesHandler() {
+        classFinder = new ClassFinder();
+        classFinder.addClassPath();
+        infoRetriever = new GraphQLObjectInfoRetriever();
+    }
+
+    public Set<GraphQLType> getAdditionalInterfacesImplementations(Class<?> root, ProcessingElementsContainer container) {
+        Set<GraphQLType> additionalFields = new HashSet<>();
+
+        additionalFields.addAll(getNewImplementations(container, classFinder, root));
+        for (Method method : graphQLObjectInfoRetriever.getOrderedMethods(root)) {
+            if (method.isBridge() || method.isSynthetic()) {
+                continue;
+            }
+            if (methodSearchAlgorithm.isFound(method)) {
+                additionalFields.addAll(getAdditionalInterfacesImplementations(method.getReturnType(), container));
+            }
+        }
+
+        for (Field field : getAllFields(root).values()) {
+            if (Modifier.isStatic(field.getModifiers())) {
+                continue;
+            }
+            if (fieldSearchAlgorithm.isFound(field)) {
+                additionalFields.addAll(getAdditionalInterfacesImplementations(field.getType(), container));
+            }
+        }
+
+        return additionalFields;
+    }
+
+    private Set<GraphQLType> getNewImplementations(ProcessingElementsContainer container, ClassFinder classFinder, Class<?> aClass) {
+        Set<GraphQLType> additionalFields = new HashSet<>();
+        if (container.getTypeRegistry().containsKey(infoRetriever.getTypeName(aClass)) && aClass.isInterface() && aClass.isAnnotationPresent(GraphQLTypeResolver.class)) {
+            ClassFilter classFilter = new SubclassClassFilter(aClass);
+            List<ClassInfo> foundClasses = new ArrayList<>();
+            classFinder.findClasses(foundClasses, classFilter);
+            for (ClassInfo classInfo : foundClasses) {
+                try {
+                    if (!(container.getTypeRegistry().containsKey(infoRetriever.getTypeName(Class.forName(classInfo.getClassName()))))) {
+                        GraphQLOutputType additionalObject = graphQLInterfaceRetriever.getInterface(Class.forName(classInfo.getClassName()), container);
+                        additionalFields.add(additionalObject);
+                    }
+                } catch (ClassNotFoundException e) {
+                    throw new GraphQLException(e);
+                }
+            }
+        }
+        return additionalFields;
+    }
+
+    public void setGraphQLObjectInfoRetriever(GraphQLObjectInfoRetriever graphQLObjectInfoRetriever) {
+        this.graphQLObjectInfoRetriever = graphQLObjectInfoRetriever;
+    }
+
+    public void setMethodSearchAlgorithm(SearchAlgorithm methodSearchAlgorithm) {
+        this.methodSearchAlgorithm = methodSearchAlgorithm;
+    }
+
+    public void setFieldSearchAlgorithm(SearchAlgorithm fieldSearchAlgorithm) {
+        this.fieldSearchAlgorithm = fieldSearchAlgorithm;
+    }
+
+    public void setGraphQLInterfaceRetriever(GraphQLInterfaceRetriever graphQLInterfaceRetriever) {
+        this.graphQLInterfaceRetriever = graphQLInterfaceRetriever;
+    }
+}

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInterfaceTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -24,15 +24,7 @@ import graphql.annotations.annotationTypes.GraphQLUnion;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.retrievers.GraphQLInterfaceRetriever;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLFieldDefinition;
-import graphql.schema.GraphQLInterfaceType;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLOutputType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLUnionType;
-import graphql.schema.TypeResolver;
+import graphql.schema.*;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -42,7 +34,6 @@ import java.util.Map;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 @SuppressWarnings("unchecked")
 public class GraphQLInterfaceTest {
@@ -52,74 +43,20 @@ public class GraphQLInterfaceTest {
         GraphQLAnnotations.getInstance().getTypeRegistry().clear();
     }
 
-    interface NoResolverIface {
-        @GraphQLField
-        String value();
-    }
-
     @Test
     public void noResolver() {
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever = GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
 
-        GraphQLObjectType object = (GraphQLObjectType) graphQLInterfaceRetriever.getInterface(NoResolverIface.class,GraphQLAnnotations.getInstance().getContainer());
+        GraphQLObjectType object = (GraphQLObjectType) graphQLInterfaceRetriever.getInterface(NoResolverIface.class, GraphQLAnnotations.getInstance().getContainer());
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 1);
         assertEquals(fields.get(0).getName(), "value");
     }
 
-    public static class Resolver implements TypeResolver {
-
-        public static Resolver getInstance() {
-            return new Resolver();
-        }
-
-        @Override
-        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
-            try {
-                return GraphQLAnnotations.object(TestObject.class);
-            } catch (GraphQLAnnotationsException e) {
-                return null;
-            }
-        }
-    }
-
-    @GraphQLTypeResolver(Resolver.class)
-    public interface BaseTestIface {
-        @GraphQLField
-        String value();
-    }
-
-    @GraphQLTypeResolver(Resolver.class)
-    public interface TestIface extends BaseTestIface {
-    }
-
-    @GraphQLUnion(possibleTypes = TestObject1.class)
-    public interface TestUnion extends BaseTestIface {
-    }
-
-    public static class TestObject implements TestIface {
-
-        @Override
-        public String value() {
-            return "a";
-        }
-    }
-
-    public static class TestObject1 implements TestUnion {
-
-        @GraphQLField
-        public int i = 1;
-
-        @Override
-        public String value() {
-            return "a";
-        }
-    }
-
     @Test
     public void test() {
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
-        GraphQLInterfaceType iface = (GraphQLInterfaceType) graphQLInterfaceRetriever.getInterface(TestIface.class,GraphQLAnnotations.getInstance().getContainer());
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever = GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
+        GraphQLInterfaceType iface = (GraphQLInterfaceType) graphQLInterfaceRetriever.getInterface(TestIface.class, GraphQLAnnotations.getInstance().getContainer());
         List<GraphQLFieldDefinition> fields = iface.getFieldDefinitions();
         assertEquals(fields.size(), 1);
         assertEquals(fields.get(0).getName(), "value");
@@ -127,8 +64,8 @@ public class GraphQLInterfaceTest {
 
     @Test
     public void testUnion() {
-        GraphQLInterfaceRetriever graphQLInterfaceRetriever=GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
-        GraphQLUnionType unionType = (GraphQLUnionType) graphQLInterfaceRetriever.getInterface(TestUnion.class,GraphQLAnnotations.getInstance().getContainer());
+        GraphQLInterfaceRetriever graphQLInterfaceRetriever = GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLInterfaceRetriever();
+        GraphQLUnionType unionType = (GraphQLUnionType) graphQLInterfaceRetriever.getInterface(TestUnion.class, GraphQLAnnotations.getInstance().getContainer());
         assertEquals(unionType.getTypes().size(), 1);
         assertEquals(unionType.getTypes().get(0).getName(), "TestObject1");
     }
@@ -141,37 +78,34 @@ public class GraphQLInterfaceTest {
         assertEquals(ifaces.get(0).getName(), "TestIface");
     }
 
-    public static class IfaceFetcher implements DataFetcher {
-
-        @Override
-        public Object get(DataFetchingEnvironment environment) {
-            return new TestObject();
-        }
-    }
-
-    public static class Query {
-        @GraphQLDataFetcher(IfaceFetcher.class)
-        @GraphQLField
-        public TestIface iface;
-    }
-
-    public static class UnionQuery {
-        @GraphQLField
-        public TestUnion union;
-
-        public UnionQuery(TestUnion union) {
-            this.union = union;
-        }
-    }
-
     @Test
     public void query() {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
+        schema = schema.transform(builder -> builder.additionalTypes(GraphQLAnnotations.additionalTypes(Query.class)));
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
         ExecutionResult result = graphQL.execute("{ iface { value } }");
         assertTrue(result.getErrors().isEmpty());
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("iface").get("value"), "a");
+    }
+
+    @Test
+    public void getAdditionalTypes_thereAreObjectsThatOnlyImplementButNotExplicitlySpecified_additionalTypesAreNotEmpty() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
+        schema = schema.transform(builder -> builder.additionalTypes(GraphQLAnnotations.additionalTypes(Query.class)));
+
+        assertTrue(!schema.getAdditionalTypes().isEmpty());
+    }
+
+    @Test
+    public void queryForObject_objectImplementsInterfaceButNotExplicitInTheSchema_worksAsExpected() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
+        schema = schema.transform(builder -> builder.additionalTypes(GraphQLAnnotations.additionalTypes(Query.class)));
+
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ anotherIface{ ... on TestObject2 {value}}}");
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("anotherIface").get("value"), "b");
     }
 
     @Test
@@ -184,4 +118,123 @@ public class GraphQLInterfaceTest {
         assertEquals(((Map<String, Map<String, String>>) result.getData()).get("union").get("value"), "a");
     }
 
+
+    @GraphQLTypeResolver(Resolver.class)
+    public interface BaseTestIface {
+
+        @GraphQLField
+        String value();
+    }
+
+    @GraphQLTypeResolver(Resolver.class)
+    public interface TestIface extends BaseTestIface {
+
+    }
+
+    @GraphQLUnion(possibleTypes = TestObject1.class)
+    public interface TestUnion extends BaseTestIface {
+
+    }
+
+    interface NoResolverIface {
+        @GraphQLField
+        String value();
+    }
+
+    public static class Resolver implements TypeResolver {
+
+        public static Resolver getInstance() {
+            return new Resolver();
+        }
+
+        @Override
+        public GraphQLObjectType getType(TypeResolutionEnvironment env) {
+            try {
+                Object object = env.getObject();
+                if (object instanceof TestObject2) {
+                    return env.getSchema().getObjectType("TestObject2");
+                }
+                if (object instanceof TestObject1) {
+                    return env.getSchema().getObjectType("TestObject1");
+                }
+                if (object instanceof TestObject) {
+                    return env.getSchema().getObjectType("TestObject");
+                }
+
+                return env.getSchema().getObjectType("TestIface");
+
+
+            } catch (GraphQLAnnotationsException e) {
+                return null;
+            }
+        }
+
+    }
+
+    public static class TestObject implements TestIface {
+
+        @Override
+        public String value() {
+            return "a";
+        }
+
+    }
+
+    public static class TestObject1 implements TestUnion {
+
+        @GraphQLField
+        public int i = 1;
+
+        @Override
+        public String value() {
+            return "a";
+        }
+
+    }
+
+    public static class TestObject2 implements TestIface {
+
+        @Override
+        public String value() {
+            return "b";
+        }
+
+    }
+
+    public static class IfaceFetcher implements DataFetcher {
+
+
+        @Override
+        public Object get(DataFetchingEnvironment environment) {
+            return new TestObject();
+        }
+    }
+
+    public static class Query {
+
+        @GraphQLDataFetcher(IfaceFetcher.class)
+        @GraphQLField
+        public TestIface iface;
+
+        @GraphQLDataFetcher(AnotherIfaceFetcher.class)
+        @GraphQLField
+        public TestIface anotherIface;
+    }
+
+    public static class UnionQuery {
+
+        @GraphQLField
+        public TestUnion union;
+
+        public UnionQuery(TestUnion union) {
+            this.union = union;
+        }
+    }
+
+    public static class AnotherIfaceFetcher implements DataFetcher {
+        @Override
+        public Object get(DataFetchingEnvironment environment) {
+            return new TestObject2();
+        }
+    }
 }


### PR DESCRIPTION
I have added a class that is responsible of the "additionalTypes" section in the GraphQL schema.
It has a class named `getAdditionalInterfacesImplementations` that put all the implementations that are not explicitly specified in the schema.
It assumes that you used the `GraphQLAnnotations.object(Query.class)` because it uses the container.
You must first build the schema as usual, and then use the `transform` function to add the additional implementations.
How to use:
```
  GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
  schema = schema.transform(builder -> builder.additionalTypes(GraphQLAnnotations.additionalTypes(Query.class)));
```
Don't merge yet, as it has not so good performances. What I do here is for every interface I scan the class path for all classes that implement this interface, and it takes a lot of time. Any suggestion of how to make it better is welcomed