### PR TITLE
DataFetcherConstructor args constructor as the annotation + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ dependencies {
 }
 ```
 
+(Maven syntax)
+
+```groovy
+<dependency>
+    <groupId>io.github.graphql-java</groupId>
+    <artifactId>graphql-java-annotations</artifactId>
+    <version>5.1</version>
+</dependency>
+```
+
 
 ## Defining Objects
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ class, it will be used instead of the default constructor.
 
 To have a union, you must annotate an interface with `@GraphQLUnion`. In the annotation, you must declare all the 
 possible types of the union, and a type resolver.
-If no type resolver is specified, `UnionTypeResovler` is used. It follows this algorithm:
+If no type resolver is specified, `UnionTypeResolver` is used. It follows this algorithm:
 The resolver assumes the the DB entity's name is the same as  the API entity's name.
  If so, it takes the result from the dataFetcher and decides to which
 API entity it should be mapped (according to the name). 
@@ -166,8 +166,42 @@ You can specify a custom data fetcher for a field with `@GraphQLDataFetcher`. Th
 which will be used as data fetcher. 
 
 An instance of the data fetcher will be created. The `args` attribute on the annotation can be used to specify a list of 
-String arguments to pass to the construcor, allowing to reuse the same class on different fields, with different parameter. 
+String arguments to pass to the constructor, allowing to reuse the same class on different fields, with different parameter.
 The `firstArgIsTargetName` attribute can also be set on `@GraphQLDataFetcher` to pass the field name as a single parameter of the constructor.
+
+Assuming you are using `@GraphQLDataFetcher` this way:
+
+```java
+@GraphQLField
+@GraphQLDataFetcher(value = HelloWorldDataFetcher.class, args = { "arg1", "arg2" })
+public String getHelloWorld(){
+    return null;
+}
+```
+
+Then the class that extends from `DataFetcher.class` will get this args to two supported constructors <br>
+Or to a constructor that expecting String array that's way (`String[] args` or `String... args`) or for a constructor that expecting the same number of args that you send with in the annotation.<br>
+You get to choose which implementation you want.
+```java
+public class HelloWorldDataFetcher implements DataFetcher<String> {
+
+    public HelloWorldDataFetcher(String[] args){
+        // Do something with your args
+    }
+
+    // Note that you need to expect the same number of args as you send with in the annotation args
+    public HelloWorldDataFetcher(String arg1, String arg2){
+        // Do something with your args
+    }
+
+    @Override
+    public String get(DataFetchingEnvironment environment) {
+        return "something";
+    }
+}
+```
+
+
 
 If no argument is needed and a `getInstance` method is present, this method will be called instead of the constructor.
 
@@ -218,7 +252,7 @@ public class HumanExtension {
 Classes marked as "extensions" will actually not define a new type, but rather set new fields on the class it extends when it will be created. 
 All GraphQL annotations can be used on extension classes.
 
-Extensions are registered in GraqhQLAnnotationProcessor by using `registerTypeExtension`. Note that extensions must be registered before the type itself is requested with `getObject()` :
+Extensions are registered in GraphQLAnnotationProcessor by using `registerTypeExtension`. Note that extensions must be registered before the type itself is requested with `getObject()` :
 
 ```
 GraphQLAnnotationsProcessor processor = GraphQLAnnotations.getInstance(); 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ dependencies {
 <dependency>
     <groupId>io.github.graphql-java</groupId>
     <artifactId>graphql-java-annotations</artifactId>
-    <version>5.1</version>
+    <version>5.2</version>
 </dependency>
 ```
 

--- a/src/main/java/graphql/annotations/processor/util/DataFetcherConstructor.java
+++ b/src/main/java/graphql/annotations/processor/util/DataFetcherConstructor.java
@@ -39,9 +39,9 @@ public class DataFetcherConstructor {
             return newInstance(annotatedDataFetcher.value());
         } else {
             try {
-                final Constructor<? extends DataFetcher> ctr = annotatedDataFetcher.value().getDeclaredConstructor(
-                        stream(args).map(v -> String.class).toArray(Class[]::new));
-                return constructNewInstance(ctr, (Object[]) args);
+                // Get the String[] constructor
+                final Constructor<? extends DataFetcher> ctr = annotatedDataFetcher.value().getDeclaredConstructor(String[].class);
+                return constructNewInstance(ctr, new Object[] {args});
             } catch (final NoSuchMethodException e) {
                 throw new GraphQLAnnotationsException("Unable to instantiate DataFetcher via constructor for: " + fieldName, e);
             }

--- a/src/test/java/graphql/annotations/processor/util/DataFetcherConstructorTest.java
+++ b/src/test/java/graphql/annotations/processor/util/DataFetcherConstructorTest.java
@@ -1,0 +1,62 @@
+package graphql.annotations.processor.util;
+
+import graphql.annotations.annotationTypes.GraphQLDataFetcher;
+import graphql.schema.DataFetcher;
+import org.testng.annotations.Test;
+
+import java.lang.annotation.Annotation;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author danieltaub on 07/05/2018.
+ */
+public class DataFetcherConstructorTest {
+    private DataFetcherConstructor constructor = new DataFetcherConstructor();
+
+    @Test
+    public void graphQLDataFetcherWithArgsTest() {
+        GraphQLDataFetcher graphQLDataFetcher = getGraphQLDataFetcher(DataFetcherMock.class, false, "Arg1", "Arg2");
+        DataFetcherMock dataFetcher = (DataFetcherMock) constructor.constructDataFetcher(null, graphQLDataFetcher);
+
+        assertEquals(dataFetcher.getArgs().length, 2);
+        assertEquals(dataFetcher.getArgs()[0], "Arg1");
+        assertEquals(dataFetcher.getArgs()[1], "Arg2");
+    }
+
+    @Test
+    public void graphQLDataFetcherDefaultCtorTest() {
+        GraphQLDataFetcher graphQLDataFetcher = getGraphQLDataFetcher(DataFetcherMock.class, false);
+        DataFetcherMock dataFetcher = (DataFetcherMock) constructor.constructDataFetcher(null, graphQLDataFetcher);
+
+        assertNull(dataFetcher.getArgs());
+    }
+
+    private GraphQLDataFetcher getGraphQLDataFetcher(final Class<? extends DataFetcher> value,
+                                                     boolean argsInTarget, String... args) {
+        GraphQLDataFetcher annotation = new GraphQLDataFetcher() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return GraphQLDataFetcher.class;
+            }
+
+            @Override
+            public Class<? extends DataFetcher> value() {
+                return value;
+            }
+
+            @Override
+            public String[] args() {
+                return args;
+            }
+
+            @Override
+            public boolean firstArgIsTargetName() {
+                return argsInTarget;
+            }
+        };
+
+        return annotation;
+    }
+}

--- a/src/test/java/graphql/annotations/processor/util/DataFetcherConstructorTest.java
+++ b/src/test/java/graphql/annotations/processor/util/DataFetcherConstructorTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations.processor.util;
 
 import graphql.annotations.annotationTypes.GraphQLDataFetcher;
@@ -16,13 +30,24 @@ public class DataFetcherConstructorTest {
     private DataFetcherConstructor constructor = new DataFetcherConstructor();
 
     @Test
-    public void graphQLDataFetcherWithArgsTest() {
+    public void graphQLDataFetcherWithArrayCtorTest() {
         GraphQLDataFetcher graphQLDataFetcher = getGraphQLDataFetcher(DataFetcherMock.class, false, "Arg1", "Arg2");
         DataFetcherMock dataFetcher = (DataFetcherMock) constructor.constructDataFetcher(null, graphQLDataFetcher);
 
         assertEquals(dataFetcher.getArgs().length, 2);
         assertEquals(dataFetcher.getArgs()[0], "Arg1");
         assertEquals(dataFetcher.getArgs()[1], "Arg2");
+    }
+
+    @Test
+    public void graphQLDataFetcherWithParamsCtorTest() {
+        GraphQLDataFetcher graphQLDataFetcher = getGraphQLDataFetcher(DataFetcherMock.class, false, "Arg1", "Arg2", "Arg3");
+        DataFetcherMock dataFetcher = (DataFetcherMock) constructor.constructDataFetcher(null, graphQLDataFetcher);
+
+        assertEquals(dataFetcher.getArgs().length, 3);
+        assertEquals(dataFetcher.getArgs()[0], "Arg1");
+        assertEquals(dataFetcher.getArgs()[1], "Arg2");
+        assertEquals(dataFetcher.getArgs()[2], "Arg3");
     }
 
     @Test

--- a/src/test/java/graphql/annotations/processor/util/DataFetcherMock.java
+++ b/src/test/java/graphql/annotations/processor/util/DataFetcherMock.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations.processor.util;
 
 import graphql.schema.DataFetcher;
@@ -9,11 +23,18 @@ import graphql.schema.DataFetchingEnvironment;
 public class DataFetcherMock implements DataFetcher {
     private String[] args;
 
-    public DataFetcherMock(String... args){
+    public DataFetcherMock(String... args) {
         this.args = args;
     }
 
-    public  DataFetcherMock(){ }
+    public DataFetcherMock(String arg1, String arg2, String arg3) {
+        this.args = new String[]{
+                arg1, arg2, arg3
+        };
+    }
+
+    public DataFetcherMock() {
+    }
 
     @Override
     public Object get(DataFetchingEnvironment environment) {

--- a/src/test/java/graphql/annotations/processor/util/DataFetcherMock.java
+++ b/src/test/java/graphql/annotations/processor/util/DataFetcherMock.java
@@ -1,0 +1,26 @@
+package graphql.annotations.processor.util;
+
+import graphql.schema.DataFetcher;
+import graphql.schema.DataFetchingEnvironment;
+
+/**
+ * @author danieltaub on 07/05/2018.
+ */
+public class DataFetcherMock implements DataFetcher {
+    private String[] args;
+
+    public DataFetcherMock(String... args){
+        this.args = args;
+    }
+
+    public  DataFetcherMock(){ }
+
+    @Override
+    public Object get(DataFetchingEnvironment environment) {
+        return null;
+    }
+
+    public String[] getArgs() {
+        return args;
+    }
+}


### PR DESCRIPTION
@GraphQLDataFetcher have args (String[]) fields, and the class thats implements DataFetcher should expect to get those args with String[] constructor...
of course that it's have Backwards compatibility
wrote some tests for the DataFetcherConstructor class