### PR TITLE
remove float support from floatfunction - only doubles are allowed

### DIFF
--- a/src/main/java/graphql/annotations/processor/typeFunctions/FloatFunction.java
+++ b/src/main/java/graphql/annotations/processor/typeFunctions/FloatFunction.java
@@ -29,7 +29,7 @@ class FloatFunction implements TypeFunction {
 
     @Override
     public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
-        return aClass == Float.class || aClass == float.class || aClass == Double.class || aClass == double.class;
+        return aClass == Double.class || aClass == double.class;
     }
 
     @Override

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -125,6 +125,12 @@ public class GraphQLObjectTest {
         public void setZ(String z) {
             this.z = z;
         }
+
+        @GraphQLField
+        @GraphQLInvokeDetached
+        public Integer doubleToInt(@GraphQLNonNull @GraphQLName("data") Double data) {
+            return data.intValue();
+        }
     }
 
     private static class TestDefaults {
@@ -172,6 +178,17 @@ public class GraphQLObjectTest {
             return new TestObjectDB("test", "test");
         }
     }
+
+    @Test
+    public void doubleIntQuery() {
+        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(TestObject.class)).build();
+        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
+        ExecutionResult result = graphQL.execute("{ doubleToInt ( data:15.0 ) }");
+        assertTrue(result.getErrors().isEmpty());
+        assertEquals(((Map<String, Integer>) result.getData()).get("doubleToInt"), Integer.valueOf(15));
+    }
+
+
 
     @Test
     public void fetchTestMappedObject_assertNameIsMappedFromDBObject(){
@@ -825,6 +842,7 @@ public class GraphQLObjectTest {
         public String getOff() {
             return "off";
         }
+
     }
 
     @Test
@@ -835,5 +853,6 @@ public class GraphQLObjectTest {
         assertNotNull(object.getFieldDefinition("inheritedOn"));
         assertNull(object.getFieldDefinition("forcedOff"));
     }
+
 
 }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -126,11 +126,6 @@ public class GraphQLObjectTest {
             this.z = z;
         }
 
-        @GraphQLField
-        @GraphQLInvokeDetached
-        public Integer doubleToInt(@GraphQLNonNull @GraphQLName("data") Double data) {
-            return data.intValue();
-        }
     }
 
     private static class TestDefaults {
@@ -178,17 +173,6 @@ public class GraphQLObjectTest {
             return new TestObjectDB("test", "test");
         }
     }
-
-    @Test
-    public void doubleIntQuery() {
-        GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(TestObject.class)).build();
-        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ doubleToInt ( data:15.0 ) }");
-        assertTrue(result.getErrors().isEmpty());
-        assertEquals(((Map<String, Integer>) result.getData()).get("doubleToInt"), Integer.valueOf(15));
-    }
-
-
 
     @Test
     public void fetchTestMappedObject_assertNameIsMappedFromDBObject(){

--- a/src/test/java/graphql/annotations/processor/typeFunctions/FloatFunctionTests.java
+++ b/src/test/java/graphql/annotations/processor/typeFunctions/FloatFunctionTests.java
@@ -32,8 +32,6 @@ public class FloatFunctionTests {
     @Test
     public void buildType_floatType_returnsGraphQLFloat() {
         DefaultTypeFunction instance = testedDefaultTypeFunction();
-        assertEquals(instance.buildType(float.class, null,null), GraphQLFloat);
-        assertEquals(instance.buildType(Float.class, null,null), GraphQLFloat);
         assertEquals(instance.buildType(Double.class, null,null), GraphQLFloat);
         assertEquals(instance.buildType(double.class, null,null), GraphQLFloat);
     }


### PR DESCRIPTION
Because GraphQLFloatType is equivalent to Double in java, and GraphQL-Java only supports Doubles, I removed the float support from the FloatFunction so no confusion will happen