### PR TITLE
Method name is not changed when it becomes field

### DIFF
--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLPrettify.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLPrettify.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
 package graphql.annotations.annotationTypes;
 
 import java.lang.annotation.ElementType;

--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLPrettify.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLPrettify.java
@@ -1,0 +1,11 @@
+package graphql.annotations.annotationTypes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLPrettify {
+}

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 package graphql.annotations.processor.retrievers.fieldBuilders.field;
 
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLPrettify;
 import graphql.annotations.processor.retrievers.fieldBuilders.Builder;
 
 import java.lang.reflect.Field;
@@ -30,7 +31,16 @@ public class FieldNameBuilder implements Builder<String> {
 
     @Override
     public String build() {
+        if (field.isAnnotationPresent(GraphQLPrettify.class) && !field.isAnnotationPresent(GraphQLName.class)) {
+            return toGraphqlName(prettifyName(field.getName()));
+        }
         GraphQLName name = field.getAnnotation(GraphQLName.class);
         return toGraphqlName(name == null ? field.getName() : name.value());
     }
+
+    private String prettifyName(String originalName) {
+        String name = originalName.replaceFirst("^(is|get|set)(.+)", "$2");
+        return Character.toLowerCase(name.charAt(0)) + name.substring(1);
+    }
+
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
@@ -30,9 +30,7 @@ public class MethodNameBuilder implements Builder<String> {
 
     @Override
     public String build() {
-        String name = method.getName().replaceFirst("^(is|get|set)(.+)", "$2");
-        name = Character.toLowerCase(name.charAt(0)) + name.substring(1);
-        GraphQLName nameAnn = method.getAnnotation(GraphQLName.class);
-        return toGraphqlName(nameAnn == null ? name : nameAnn.value());
+        GraphQLName name = method.getAnnotation(GraphQLName.class);
+        return toGraphqlName(name == null ? method.getName() : name.value());
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -15,6 +15,7 @@
 package graphql.annotations.processor.retrievers.fieldBuilders.method;
 
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.GraphQLPrettify;
 import graphql.annotations.processor.retrievers.fieldBuilders.Builder;
 
 import java.lang.reflect.Method;
@@ -30,7 +31,15 @@ public class MethodNameBuilder implements Builder<String> {
 
     @Override
     public String build() {
+        if (method.isAnnotationPresent(GraphQLPrettify.class) && !method.isAnnotationPresent(GraphQLName.class)) {
+            return toGraphqlName(pretifyName(method.getName()));
+        }
         GraphQLName name = method.getAnnotation(GraphQLName.class);
         return toGraphqlName(name == null ? method.getName() : name.value());
+    }
+
+    private String pretifyName(String originalName) {
+        String name = originalName.replaceFirst("^(is|get|set)(.+)", "$2");
+        return Character.toLowerCase(name.charAt(0)) + name.substring(1);
     }
 }

--- a/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDataFetcherTest.java
@@ -20,20 +20,14 @@ import graphql.annotations.annotationTypes.GraphQLDataFetcher;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.GraphQLAnnotations;
-import graphql.schema.DataFetcher;
-import graphql.schema.DataFetchingEnvironment;
-import graphql.schema.GraphQLObjectType;
-import graphql.schema.GraphQLSchema;
-import graphql.schema.PropertyDataFetcher;
+import graphql.schema.*;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.util.HashMap;
 
 import static graphql.schema.GraphQLSchema.newSchema;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 public class GraphQLDataFetcherTest {
 
@@ -53,7 +47,7 @@ public class GraphQLDataFetcherTest {
         final ExecutionResult result = graphql.execute("{sample {isGreat isBad}}");
 
         // Then
-        final HashMap<String, Object> data = (HashMap) result.getData();
+        final HashMap<String, Object> data = result.getData();
         assertNotNull(data);
         assertTrue(((HashMap<String, Boolean>) data.get("sample")).get("isGreat"));
         assertTrue(((HashMap<String, Boolean>) data.get("sample")).get("isBad"));
@@ -70,7 +64,7 @@ public class GraphQLDataFetcherTest {
         final ExecutionResult result = graphql.execute("{great}");
 
         // Then
-        final HashMap<String, Object> data = (HashMap) result.getData();
+        final HashMap<String, Object> data = result.getData();
         assertNotNull(data);
         assertFalse((Boolean)data.get("great"));
     }
@@ -83,12 +77,12 @@ public class GraphQLDataFetcherTest {
         final GraphQL graphql = GraphQL.newGraphQL(schema).build();
 
         // When
-        final ExecutionResult result = graphql.execute("{sample {bad}}");
+        final ExecutionResult result = graphql.execute("{sample {isBad}}");
 
         // Then
-        final HashMap<String, Object> data = (HashMap) result.getData();
+        final HashMap<String, Object> data = result.getData();
         assertNotNull(data);
-        assertTrue(((HashMap<String,Boolean>)data.get("sample")).get("bad"));
+        assertTrue(((HashMap<String,Boolean>)data.get("sample")).get("isBad"));
     }
 
     @GraphQLName("Query")

--- a/src/test/java/graphql/annotations/GraphQLEnumTest.java
+++ b/src/test/java/graphql/annotations/GraphQLEnumTest.java
@@ -19,7 +19,7 @@ import graphql.GraphQL;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.GraphQLAnnotations;
-import graphql.schema.*;
+import graphql.schema.GraphQLObjectType;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
@@ -72,8 +72,8 @@ public class GraphQLEnumTest {
         GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
         GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
-        ExecutionResult result = graphql.execute("{ defaultUser{ name } }");
-        assertEquals(result.getData().toString(), "{defaultUser={name=ONE}}");
+        ExecutionResult result = graphql.execute("{ defaultUser{ getName } }");
+        assertEquals(result.getData().toString(), "{defaultUser={getName=ONE}}");
     }
 
     @Test
@@ -81,8 +81,8 @@ public class GraphQLEnumTest {
         GraphQLObjectType queryObject = GraphQLAnnotations.object(Query.class);
         GraphQL graphql = GraphQL.newGraphQL(newSchema().query(queryObject).build()).build();
 
-        ExecutionResult result = graphql.execute("{ user(param:TWO){ name } }");
-        assertEquals(result.getData().toString(), "{user={name=TWO}}");
+        ExecutionResult result = graphql.execute("{ user(param:TWO){ getName } }");
+        assertEquals(result.getData().toString(), "{user={getName=TWO}}");
     }
 
 

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -23,6 +23,7 @@ import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.schema.*;
 import org.testng.annotations.Test;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
@@ -80,7 +81,7 @@ public class GraphQLExtensionsTest {
         }
 
         @GraphQLField
-        public String getField() {
+        public String field() {
             return "invalid";
         }
     }
@@ -102,7 +103,7 @@ public class GraphQLExtensionsTest {
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 5);
 
-        fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
+        fields.sort(Comparator.comparing(GraphQLFieldDefinition::getName));
 
         assertEquals(fields.get(0).getName(), "field");
         assertEquals(fields.get(1).getName(), "field2");
@@ -122,7 +123,7 @@ public class GraphQLExtensionsTest {
         GraphQLSchema schemaInherited = newSchema().query(object).build();
 
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{field field2 field3 field4 field5}", new GraphQLExtensionsTest.TestObject());
-        Map<String, Object> data = (Map<String, Object>) result.getData();
+        Map<String, Object> data = result.getData();
         assertEquals(data.get("field"), "test");
         assertEquals(data.get("field2"), "test test2");
         assertEquals(data.get("field3"), "test test3");

--- a/src/test/java/graphql/annotations/GraphQLFragmentTest.java
+++ b/src/test/java/graphql/annotations/GraphQLFragmentTest.java
@@ -28,12 +28,7 @@ import graphql.schema.TypeResolver;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 import static org.testng.AssertJUnit.assertEquals;
 
@@ -76,7 +71,7 @@ public class GraphQLFragmentTest {
         GraphQL graphQL2 = GraphQL.newGraphQL(schema).build();
 
         // When
-        ExecutionResult graphQLResult = graphQL2.execute("{items { ... on MyObject {a, my {b}} ... on MyObject2 {a, b}  }}", new RootObject());
+        ExecutionResult graphQLResult = graphQL2.execute("{getItems { ... on MyObject {getA, getMy {getB}} ... on MyObject2 {getA, getB}  }}", new RootObject());
         Set resultMap = ((Map) graphQLResult.getData()).entrySet();
 
         // Then

--- a/src/test/java/graphql/annotations/GraphQLInputTest.java
+++ b/src/test/java/graphql/annotations/GraphQLInputTest.java
@@ -21,13 +21,17 @@ import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLTypeResolver;
 import graphql.annotations.processor.GraphQLAnnotations;
-import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
-import graphql.schema.*;
+import graphql.schema.GraphQLInputObjectType;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import graphql.schema.TypeResolver;
 import org.testng.annotations.Test;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.assertEquals;
@@ -284,9 +288,9 @@ public class GraphQLInputTest {
         // arrange + act
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryInputAndOutput.class)).build();
         // assert
-        assertEquals(schema.getQueryType().getFieldDefinition("hero").getType().getName(), "hero");
-        assertEquals(schema.getQueryType().getFieldDefinition("string").getArgument("input").getType().getName(), "Inputhero");
-        assertEquals(((GraphQLInputObjectType) schema.getQueryType().getFieldDefinition("string")
+        assertEquals(schema.getQueryType().getFieldDefinition("getHero").getType().getName(), "hero");
+        assertEquals(schema.getQueryType().getFieldDefinition("getString").getArgument("input").getType().getName(), "Inputhero");
+        assertEquals(((GraphQLInputObjectType) schema.getQueryType().getFieldDefinition("getString")
                 .getArgument("input").getType()).getField("skill").getType().getName(), "InputSkill");
     }
 
@@ -295,8 +299,8 @@ public class GraphQLInputTest {
         // arrange + act
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QueryInputAndOutput2.class)).build();
         // assert
-        assertEquals(schema.getQueryType().getFieldDefinition("skill").getType().getName(), "Skill");
-        assertEquals(schema.getQueryType().getFieldDefinition("a").getArgument("skill").getType().getName(), "InputSkill");
+        assertEquals(schema.getQueryType().getFieldDefinition("getSkill").getType().getName(), "Skill");
+        assertEquals(schema.getQueryType().getFieldDefinition("getA").getArgument("skill").getType().getName(), "InputSkill");
     }
 
     @GraphQLName("A")
@@ -345,13 +349,13 @@ public class GraphQLInputTest {
         // arrange + act
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(QuerySameNameWithChildren.class)).build();
         // assert
-        assertEquals(schema.getQueryType().getFieldDefinition("aout").getType().getName(), "A");
-        assertEquals(schema.getQueryType().getFieldDefinition("aout").getType().getClass(),GraphQLObjectType.class);
-        assertEquals(schema.getQueryType().getFieldDefinition("bout").getType().getName(), "B");
-        assertEquals(schema.getQueryType().getFieldDefinition("bout").getType().getClass(),GraphQLObjectType.class);
-        assertEquals(schema.getQueryType().getFieldDefinition("a").getArgument("input").getType().getName(), "InputA");
-        assertEquals(schema.getQueryType().getFieldDefinition("a").getArgument("input").getType().getClass(), GraphQLInputObjectType.class);
-        assertEquals(schema.getQueryType().getFieldDefinition("b").getArgument("input").getType().getClass(), GraphQLInputObjectType.class);
+        assertEquals(schema.getQueryType().getFieldDefinition("getAout").getType().getName(), "A");
+        assertEquals(schema.getQueryType().getFieldDefinition("getAout").getType().getClass(),GraphQLObjectType.class);
+        assertEquals(schema.getQueryType().getFieldDefinition("getBout").getType().getName(), "B");
+        assertEquals(schema.getQueryType().getFieldDefinition("getBout").getType().getClass(),GraphQLObjectType.class);
+        assertEquals(schema.getQueryType().getFieldDefinition("getA").getArgument("input").getType().getName(), "InputA");
+        assertEquals(schema.getQueryType().getFieldDefinition("getA").getArgument("input").getType().getClass(), GraphQLInputObjectType.class);
+        assertEquals(schema.getQueryType().getFieldDefinition("getB").getArgument("input").getType().getClass(), GraphQLInputObjectType.class);
 
     }
 }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -22,14 +22,12 @@ import graphql.annotations.annotationTypes.GraphQLNonNull;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.retrievers.GraphQLFieldRetriever;
-import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
 import graphql.annotations.processor.retrievers.GraphQLObjectInfoRetriever;
 import graphql.annotations.processor.searchAlgorithms.BreadthFirstSearch;
 import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.typeBuilders.InputObjectBuilder;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.schema.*;
-
 import graphql.schema.GraphQLType;
 import graphql.schema.idl.SchemaParser;
 import graphql.schema.idl.SchemaPrinter;
@@ -44,10 +42,7 @@ import java.util.function.Supplier;
 import static graphql.Scalars.GraphQLString;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLSchema.newSchema;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 @SuppressWarnings("unchecked")
 public class GraphQLObjectTest {
@@ -358,10 +353,10 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(TestAccessors.class);
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 2);
-        fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
+        fields.sort(Comparator.comparing(GraphQLFieldDefinition::getName));
 
-        assertEquals(fields.get(1).getName(), "value");
-        assertEquals(fields.get(0).getName(), "anotherValue");
+        assertEquals(fields.get(0).getName(), "getValue");
+        assertEquals(fields.get(1).getName(), "setAnotherValue");
     }
 
 
@@ -438,7 +433,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = GraphQLAnnotations.object(OnMethodTest.class);
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 1);
-        assertEquals(fields.get(0).getName(), "value");
+        assertEquals(fields.get(0).getName(), "getValue");
     }
 
     public static class TestFetcher implements DataFetcher {
@@ -618,7 +613,7 @@ public class GraphQLObjectTest {
         }
 
         @GraphQLField
-        public Collection<TestInputArgument> getInputs() {
+        public Collection<TestInputArgument> inputs() {
             return inputs;
         }
 
@@ -670,7 +665,7 @@ public class GraphQLObjectTest {
         GraphQLSchema schema = newSchema().query(object).build();
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{ test2(arg: {inputs:[{ a:\"ok\", b:2 }]}, other:0) }", new TestObjectInput());
         assertTrue(result.getErrors().isEmpty());
-        Map<String, Object> v = (Map<String, Object>) result.getData();
+        Map<String, Object> v = result.getData();
         assertEquals(v.get("test2"), "ok");
     }
 
@@ -817,12 +812,12 @@ public class GraphQLObjectTest {
         @GraphQLField(false)
         public String forcedOff;
 
-        public String getOn() {
+        public String on() {
             return "on";
         }
 
         @GraphQLField(false)
-        public String getOff() {
+        public String off() {
             return "off";
         }
     }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * <p>
  * http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -78,7 +78,7 @@ public class GraphQLObjectTest {
         }
 
         @GraphQLField
-        public String fieldWithArgsAndEnvironment(DataFetchingEnvironment env,@GraphQLName("a") String a, @GraphQLName("b") String b) {
+        public String fieldWithArgsAndEnvironment(DataFetchingEnvironment env, @GraphQLName("a") String a, @GraphQLName("b") String b) {
             return a;
         }
 
@@ -141,7 +141,7 @@ public class GraphQLObjectTest {
         public String aaa;
     }
 
-    public static class TestObjectDB{
+    public static class TestObjectDB {
         public String aaa;
 
         private String name;
@@ -151,11 +151,12 @@ public class GraphQLObjectTest {
         }
 
         public TestObjectDB(String name, String aaa) {
-            this.name = name; this.aaa=aaa;
+            this.name = name;
+            this.aaa = aaa;
         }
     }
 
-    public static class TestQuery{
+    public static class TestQuery {
         @GraphQLField
         @GraphQLDataFetcher(ObjectFetcher.class)
         public TestMappedObject object;
@@ -169,15 +170,62 @@ public class GraphQLObjectTest {
         }
     }
 
+    public static class NameTest {
+        @GraphQLField
+        public Boolean isCool;
+
+        @GraphQLField
+        @GraphQLPrettify
+        public Boolean isAwesome;
+
+        @GraphQLField
+        @GraphQLPrettify
+        @GraphQLName("yarinnn")
+        public Boolean isYarin;
+
+        @GraphQLField
+        public String getX() {
+            return "Asdf0";
+        }
+
+        @GraphQLField
+        @GraphQLPrettify
+        public String getY() {
+            return "asd";
+        }
+
+        @GraphQLField
+        @GraphQLPrettify
+        @GraphQLName("daniel")
+        public String setM(){
+            return "Asdf";
+        }
+
+    }
+
     @Test
-    public void fetchTestMappedObject_assertNameIsMappedFromDBObject(){
+    public void objectCreation_nameIsCorrect() {
+        // Act
+        GraphQLObjectType object = GraphQLAnnotations.object(NameTest.class);
+
+        // Assert
+        assertNotNull(object.getFieldDefinition("awesome"));
+        assertNotNull(object.getFieldDefinition("isCool"));
+        assertNotNull(object.getFieldDefinition("yarinnn"));
+        assertNotNull(object.getFieldDefinition("getX"));
+        assertNotNull(object.getFieldDefinition("y"));
+        assertNotNull(object.getFieldDefinition("daniel"));
+    }
+
+    @Test
+    public void fetchTestMappedObject_assertNameIsMappedFromDBObject() {
         GraphQLObjectType object = GraphQLAnnotations.object(TestQuery.class);
         GraphQLSchema schema = newSchema().query(object).build();
 
         ExecutionResult result = GraphQL.newGraphQL(schema).build().execute("{object {name aaa}}");
         assertTrue(result.getErrors().isEmpty());
-        assertEquals(((LinkedHashMap)(((LinkedHashMap)result.getData()).get("object"))).get("name"), "test");
-        assertEquals(((LinkedHashMap)(((LinkedHashMap)result.getData()).get("object"))).get("aaa"), "test");
+        assertEquals(((LinkedHashMap) (((LinkedHashMap) result.getData()).get("object"))).get("name"), "test");
+        assertEquals(((LinkedHashMap) (((LinkedHashMap) result.getData()).get("object"))).get("aaa"), "test");
     }
 
     @Test
@@ -540,7 +588,7 @@ public class GraphQLObjectTest {
     @Test
     public void recursiveTypes() {
         GraphQLAnnotations graphQLAnnotations = new GraphQLAnnotations();
-        GraphQLObjectType object = graphQLAnnotations.getObjectHandler().getObject(Class1.class,graphQLAnnotations.getContainer());
+        GraphQLObjectType object = graphQLAnnotations.getObjectHandler().getObject(Class1.class, graphQLAnnotations.getContainer());
         GraphQLSchema schema = newSchema().query(object).build();
 
         Class1 class1 = new Class1();
@@ -593,7 +641,7 @@ public class GraphQLObjectTest {
         assertEquals(object.getFieldDefinition("id").getType(), GraphQLString);
     }
 
-    public  static class TestInputArgument {
+    public static class TestInputArgument {
         @GraphQLField
         public String a;
         @GraphQLField
@@ -621,8 +669,7 @@ public class GraphQLObjectTest {
     }
 
 
-
-    public  static class TestObjectInput {
+    public static class TestObjectInput {
         @GraphQLField
         public String test(@GraphQLName("other") int other, @GraphQLName("arg") TestInputArgument arg) {
             return arg.a;
@@ -634,7 +681,7 @@ public class GraphQLObjectTest {
         }
     }
 
-    public static class InputObject{
+    public static class InputObject {
         @GraphQLField
         int a;
 
@@ -688,7 +735,7 @@ public class GraphQLObjectTest {
 
         @Override
         public GraphQLType buildType(boolean input, Class<?> aClass, AnnotatedType annotatedType, ProcessingElementsContainer container) {
-            return buildType(input,aClass,annotatedType);
+            return buildType(input, aClass, annotatedType);
         }
 
         @Override

--- a/src/test/java/graphql/annotations/GraphQLUnionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLUnionTest.java
@@ -106,10 +106,10 @@ public class GraphQLUnionTest {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        String query = "{ pet(kindOfPet:\"dog\"){ ... on Cat {mew}, ... on Dog{waf}} }";
+        String query = "{ getPet(kindOfPet:\"dog\"){ ... on Cat {mew}, ... on Dog{waf}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
-        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("pet").get("waf"), "waf");
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("getPet").get("waf"), "waf");
     }
 
     @Test
@@ -117,10 +117,10 @@ public class GraphQLUnionTest {
         GraphQLSchema schema = newSchema().query(GraphQLAnnotations.object(Query.class)).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        String query = "{ pet(kindOfPet:\"cat\"){ ... on Cat {mew}, ... on Dog{waf}} }";
+        String query = "{ getPet(kindOfPet:\"cat\"){ ... on Cat {mew}, ... on Dog{waf}} }";
         ExecutionResult result = graphQL.execute(query);
         assertTrue(result.getErrors().isEmpty());
-        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("pet").get("mew"), "mew");
+        assertEquals(((Map<String, Map<String, String>>) result.getData()).get("getPet").get("mew"), "mew");
     }
 
     static class Screen implements Hardware {

--- a/src/test/java/graphql/annotations/RelayTest.java
+++ b/src/test/java/graphql/annotations/RelayTest.java
@@ -110,20 +110,20 @@ public class RelayTest {
         assertTrue(doSomething.getType() instanceof GraphQLObjectType);
         GraphQLObjectType returnType = (GraphQLObjectType) doSomething.getType();
 
-        assertNotNull(returnType.getFieldDefinition("i"));
+        assertNotNull(returnType.getFieldDefinition("getI"));
         assertNotNull(returnType.getFieldDefinition("clientMutationId"));
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
-        ExecutionResult result = graphQL.execute("mutation { doSomething(input: {clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
+        ExecutionResult result = graphQL.execute("mutation { doSomething(input: {clientMutationId: \"1\"}) { getI clientMutationId } }", new TestObject());
 
         assertEquals(result.getErrors().size(), 0);
 
         Map<String, Object> returns = (Map<String, Object>) ((Map<String, Object>) result.getData()).get("doSomething");
 
-        assertEquals(returns.get("i"), 0);
+        assertEquals(returns.get("getI"), 0);
         assertEquals(returns.get("clientMutationId"), "1");
     }
 
@@ -139,13 +139,13 @@ public class RelayTest {
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
-        ExecutionResult result = graphQL.execute("mutation { doSomethingI(input: {clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
+        ExecutionResult result = graphQL.execute("mutation { doSomethingI(input: {clientMutationId: \"1\"}) { getI clientMutationId } }", new TestObject());
 
         assertEquals(result.getErrors().size(), 0);
 
         Map<String, Object> returns = (Map<String, Object>) ((Map<String, Object>) result.getData()).get("doSomethingI");
 
-        assertEquals(returns.get("i"), 0);
+        assertEquals(returns.get("getI"), 0);
         assertEquals(returns.get("clientMutationId"), "1");
     }
 
@@ -171,20 +171,20 @@ public class RelayTest {
         assertTrue(doSomethingElse.getType() instanceof GraphQLObjectType);
         GraphQLObjectType returnType = (GraphQLObjectType) doSomethingElse.getType();
 
-        assertNotNull(returnType.getFieldDefinition("i"));
+        assertNotNull(returnType.getFieldDefinition("getI"));
         assertNotNull(returnType.getFieldDefinition("clientMutationId"));
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).queryExecutionStrategy(new EnhancedExecutionStrategy()).build();
 
-        ExecutionResult result = graphQL.execute("mutation { doSomethingElse(input: {a: 0, b: 1, clientMutationId: \"1\"}) { i clientMutationId } }", new TestObject());
+        ExecutionResult result = graphQL.execute("mutation { doSomethingElse(input: {a: 0, b: 1, clientMutationId: \"1\"}) { getI clientMutationId } }", new TestObject());
 
         assertEquals(result.getErrors().size(), 0);
 
         Map<String, Object> returns = (Map<String, Object>) ((Map<String, Object>) result.getData()).get("doSomethingElse");
 
-        assertEquals(returns.get("i"), -1);
+        assertEquals(returns.get("getI"), -1);
         assertEquals(returns.get("clientMutationId"), "1");
     }
 
@@ -208,7 +208,7 @@ public class RelayTest {
         assertTrue(doSomethingElse.getType() instanceof GraphQLObjectType);
         GraphQLObjectType returnType = (GraphQLObjectType) doSomethingElse.getType();
 
-        assertNotNull(returnType.getFieldDefinition("i"));
+        assertNotNull(returnType.getFieldDefinition("getI"));
         assertNotNull(returnType.getFieldDefinition("clientMutationId"));
 
         GraphQLSchema schema = GraphQLSchema.newSchema().query(object).mutation(object).build();
@@ -221,13 +221,13 @@ public class RelayTest {
         inputVariables.put("b", 1);
         inputVariables.put("clientMutationId", "1");
         variables.put("input", inputVariables);
-        ExecutionResult result = graphQL.execute("mutation VariableMutation($input:DoSomethingElseInput!) { doSomethingElse(input: $input) { i clientMutationId } }", new TestObject(), variables);
+        ExecutionResult result = graphQL.execute("mutation VariableMutation($input:DoSomethingElseInput!) { doSomethingElse(input: $input) { getI clientMutationId } }", new TestObject(), variables);
 
         assertEquals(result.getErrors().size(), 0);
 
         Map<String, Object> returns = (Map<String, Object>) ((Map<String, Object>) result.getData()).get("doSomethingElse");
 
-        assertEquals(returns.get("i"), -1);
+        assertEquals(returns.get("getI"), -1);
         assertEquals(returns.get("clientMutationId"), "1");
     }
 }

--- a/src/test/java/graphql/annotations/connection/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/connection/GraphQLConnectionTest.java
@@ -150,22 +150,6 @@ public class GraphQLConnectionTest {
     }
 
     @Test
-    public void customConnection() {
-        GraphQLObjectType object = GraphQLAnnotations.object(TestCustomConnection.class);
-        GraphQLSchema schema = newSchema().query(object).build();
-
-        GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
-                new TestCustomConnection(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
-
-        assertTrue(result.getErrors().isEmpty());
-        Map<String, Object> data = result.getData();
-        Map<String, Object> objs = (Map<String, Object>) (data.get("objs"));
-        List edges = (List) objs.get("edges");
-        assertEquals(edges.size(), 0);
-    }
-
-    @Test
     public void customRelayMethodList() {
         try {
             GraphQLAnnotations.getInstance().setRelay(new CustomRelay());

--- a/src/test/java/graphql/annotations/connection/GraphQLConnectionTest.java
+++ b/src/test/java/graphql/annotations/connection/GraphQLConnectionTest.java
@@ -30,16 +30,17 @@ import graphql.schema.GraphQLSchema;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static graphql.annotations.processor.util.RelayKit.EMPTY_CONNECTION;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static java.util.Collections.emptyList;
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
+import static org.testng.Assert.*;
 
 @SuppressWarnings("unchecked")
 public class GraphQLConnectionTest {
@@ -228,12 +229,12 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getObjs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
 
-        testResult("objs", result);
+        testResult("getObjs", result);
 
     }
 
@@ -271,12 +272,12 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objStream(first: 1) { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getObjStream(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
 
-        testResult("objStream", result);
+        testResult("getObjStream", result);
     }
 
     @Test
@@ -285,12 +286,12 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ nonNullObjs(first: 1) { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getNonNullObjs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
 
-        testResult("nonNullObjs", result);
+        testResult("getNonNullObjs", result);
     }
 
     @Test
@@ -299,14 +300,14 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ nullObj(first: 1) { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getNullObj(first: 1) { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
 
         Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = result.getData();
 
-        assertEquals(data.get("nullObj").get("edges").size(), 0);
+        assertEquals(data.get("getNullObj").get("edges").size(), 0);
     }
 
     @Test
@@ -315,12 +316,12 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objStreamWithParam(first: 1, filter:\"hel\") { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getObjStreamWithParam(first: 1, filter:\"hel\") { edges { cursor node { id, val } } } }",
                 new TestConnections(emptyList()));
         assertTrue(result.getErrors().isEmpty());
 
         Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = result.getData();
-        List<Map<String, Map<String, Object>>> edges = data.get("objStreamWithParam").get("edges");
+        List<Map<String, Map<String, Object>>> edges = data.get("getObjStreamWithParam").get("edges");
 
         assertEquals(edges.size(), 0);
     }
@@ -331,13 +332,13 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objStreamWithParam(first: 2, filter:\"hel\") { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getObjStreamWithParam(first: 2, filter:\"hel\") { edges { cursor node { id, val } } } }",
                 new TestConnections(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"), new Obj("4", "hello world"), new Obj("5", "hello again"))));
 
         assertTrue(result.getErrors().isEmpty());
 
         Map<String, Map<String, List<Map<String, Map<String, Object>>>>> data = result.getData();
-        List<Map<String, Map<String, Object>>> edges = data.get("objStreamWithParam").get("edges");
+        List<Map<String, Map<String, Object>>> edges = data.get("getObjStreamWithParam").get("edges");
 
         assertEquals(edges.size(), 2);
         assertEquals(edges.get(0).get("node").get("id"), "2");
@@ -383,12 +384,12 @@ public class GraphQLConnectionTest {
         GraphQLSchema schema = newSchema().query(object).build();
 
         GraphQL graphQL = GraphQL.newGraphQL(schema).build();
-        ExecutionResult result = graphQL.execute("{ objs(first: 1) { edges { cursor node { id, val } } } }",
+        ExecutionResult result = graphQL.execute("{ getObjs(first: 1) { edges { cursor node { id, val } } } }",
                 new TestCustomConnection(Arrays.asList(new Obj("1", "test"), new Obj("2", "hello"), new Obj("3", "world"))));
 
         assertTrue(result.getErrors().isEmpty());
-        Map<String, Object> data = (Map<String, Object>) result.getData();
-        Map<String, Object> objs = (Map<String, Object>) (data.get("objs"));
+        Map<String, Object> data = result.getData();
+        Map<String, Object> objs = (Map<String, Object>) (data.get("getObjs"));
         List edges = (List) objs.get("edges");
         assertEquals(edges.size(), 0);
     }

--- a/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilderTest.java
+++ b/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilderTest.java
@@ -64,7 +64,7 @@ public class MethodNameBuilderTest {
         String name = methodNameBuilder.build();
 
         // assert
-        assertEquals(name, "test");
+        assertEquals(name, "getTest");
     }
 
     @Test
@@ -77,7 +77,7 @@ public class MethodNameBuilderTest {
         String name = methodNameBuilder.build();
 
         // assert
-        assertEquals(name, "test");
+        assertEquals(name, "isTest");
     }
 
     @Test
@@ -90,7 +90,7 @@ public class MethodNameBuilderTest {
         String name = methodNameBuilder.build();
 
         // assert
-        assertEquals(name, "test");
+        assertEquals(name, "setTest");
     }
 
 


### PR DESCRIPTION
The name is not changed when the method becomes field
i.e the name of the field that is generated from a method is exactly the same name of the method
(We don't remove the get|set|is prefix)