### PR TITLE
Add global settings to force prettify on all field/method

### DIFF
--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLFieldRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLFieldRetriever.java
@@ -55,6 +55,8 @@ public class GraphQLFieldRetriever {
 
     private DataFetcherConstructor dataFetcherConstructor;
 
+    private boolean alwaysPrettify = false;
+
     public GraphQLFieldRetriever(DataFetcherConstructor dataFetcherConstructor) {
         this.dataFetcherConstructor = dataFetcherConstructor;
     }
@@ -66,7 +68,7 @@ public class GraphQLFieldRetriever {
     public GraphQLFieldDefinition getField(Method method, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLFieldDefinition.Builder builder = newFieldDefinition();
         TypeFunction typeFunction = getTypeFunction(method, container);
-        builder.name(new MethodNameBuilder(method).build());
+        builder.name(new MethodNameBuilder(method).alwaysPrettify(alwaysPrettify).build());
         GraphQLOutputType outputType = (GraphQLOutputType) new MethodTypeBuilder(method, typeFunction, container, false).build();
 
         boolean isConnection = ConnectionUtil.isConnection(method, outputType);
@@ -85,7 +87,7 @@ public class GraphQLFieldRetriever {
 
     public GraphQLFieldDefinition getField(Field field, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLFieldDefinition.Builder builder = newFieldDefinition();
-        builder.name(new FieldNameBuilder(field).build());
+        builder.name(new FieldNameBuilder(field).alwaysPrettify(alwaysPrettify).build());
         TypeFunction typeFunction = getTypeFunction(field, container);
 
         GraphQLType outputType = typeFunction.buildType(field.getType(), field.getAnnotatedType(), container);
@@ -104,7 +106,7 @@ public class GraphQLFieldRetriever {
 
     public GraphQLInputObjectField getInputField(Method method, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLInputObjectField.Builder builder = newInputObjectField();
-        builder.name(new MethodNameBuilder(method).build());
+        builder.name(new MethodNameBuilder(method).alwaysPrettify(alwaysPrettify).build());
         TypeFunction typeFunction = getTypeFunction(method, container);
         GraphQLInputType inputType = (GraphQLInputType) new MethodTypeBuilder(method, typeFunction, container, true).build();
         return builder.type(inputType).description(new DescriptionBuilder(method).build()).build();
@@ -112,7 +114,7 @@ public class GraphQLFieldRetriever {
 
     public GraphQLInputObjectField getInputField(Field field, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLInputObjectField.Builder builder = newInputObjectField();
-        builder.name(new FieldNameBuilder(field).build());
+        builder.name(new FieldNameBuilder(field).alwaysPrettify(alwaysPrettify).build());
         TypeFunction typeFunction = getTypeFunction(field, container);
         GraphQLType graphQLType = typeFunction.buildType(true, field.getType(), field.getAnnotatedType(), container);
         return builder.type((GraphQLInputType) graphQLType).description(new DescriptionBuilder(field).build()).build();
@@ -193,6 +195,10 @@ public class GraphQLFieldRetriever {
             typeRegistry.put(type.getName(), type);
         }
         return type;
+    }
+
+    public void setAlwaysPrettify(boolean alwaysPrettify) {
+        this.alwaysPrettify = alwaysPrettify;
     }
 
     @Reference(policy = ReferencePolicy.DYNAMIC, policyOption = ReferencePolicyOption.GREEDY)

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/field/FieldNameBuilder.java
@@ -25,13 +25,20 @@ import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 public class FieldNameBuilder implements Builder<String> {
     private Field field;
 
+    private boolean alwaysPrettify = false;
+
     public FieldNameBuilder(Field field) {
         this.field = field;
     }
 
+    public FieldNameBuilder alwaysPrettify(boolean alwaysPrettify) {
+        this.alwaysPrettify = alwaysPrettify;
+        return this;
+    }
+
     @Override
     public String build() {
-        if (field.isAnnotationPresent(GraphQLPrettify.class) && !field.isAnnotationPresent(GraphQLName.class)) {
+        if ((alwaysPrettify || field.isAnnotationPresent(GraphQLPrettify.class)) && !field.isAnnotationPresent(GraphQLName.class)) {
             return toGraphqlName(prettifyName(field.getName()));
         }
         GraphQLName name = field.getAnnotation(GraphQLName.class);

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilder.java
@@ -17,6 +17,7 @@ package graphql.annotations.processor.retrievers.fieldBuilders.method;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.annotationTypes.GraphQLPrettify;
 import graphql.annotations.processor.retrievers.fieldBuilders.Builder;
+import graphql.annotations.processor.retrievers.fieldBuilders.field.FieldNameBuilder;
 
 import java.lang.reflect.Method;
 
@@ -25,13 +26,20 @@ import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
 public class MethodNameBuilder implements Builder<String> {
     private Method method;
 
+    private boolean alwaysPrettify = false;
+
     public MethodNameBuilder(Method method) {
         this.method = method;
     }
 
+    public MethodNameBuilder alwaysPrettify(boolean alwaysPrettify) {
+        this.alwaysPrettify = alwaysPrettify;
+        return this;
+    }
+
     @Override
     public String build() {
-        if (method.isAnnotationPresent(GraphQLPrettify.class) && !method.isAnnotationPresent(GraphQLName.class)) {
+        if ((alwaysPrettify || method.isAnnotationPresent(GraphQLPrettify.class)) && !method.isAnnotationPresent(GraphQLName.class)) {
             return toGraphqlName(prettifyName(method.getName()));
         }
         GraphQLName name = method.getAnnotation(GraphQLName.class);

--- a/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilderTest.java
+++ b/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/method/MethodNameBuilderTest.java
@@ -68,6 +68,19 @@ public class MethodNameBuilderTest {
     }
 
     @Test
+    public void build_graphQLNameAnnotationNotExistsWithGetPrefixAndPrettify_returnCorrectName() throws NoSuchMethodException {
+        // arrange
+        Method method = getClass().getMethod("getTest");
+        MethodNameBuilder methodNameBuilder = new MethodNameBuilder(method);
+
+        // act
+        String name = methodNameBuilder.alwaysPrettify(true).build();
+
+        // assert
+        assertEquals(name, "test");
+    }
+
+    @Test
     public void build_graphQLNameAnnotationNotExistsWithIsPrefix_returnCorrectName() throws NoSuchMethodException{
         // arrange
         Method method = getClass().getMethod("isTest");


### PR DESCRIPTION
Fix for #177 #181 : Added a global settings to prettify all fields without having to use @GraphQLPrettify.
You can use it by calling setAlwaysPrettify on GraphQLFieldRetriever :
GraphQLAnnotations.getInstance().getObjectHandler().getTypeRetriever().getGraphQLFieldRetriever().setAlwaysPrettify(true);
