### PR TITLE
Make it possible to provide custom prefixes AND postfixes for input objects

### DIFF
--- a/src/main/java/graphql/annotations/processor/ProcessingElementsContainer.java
+++ b/src/main/java/graphql/annotations/processor/ProcessingElementsContainer.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
-import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_POSTFIX;
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_SUFFIX;
 import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
 
 public class ProcessingElementsContainer {
@@ -39,7 +39,7 @@ public class ProcessingElementsContainer {
     private Map<Class<?>, Set<Class<?>>> extensionsTypeRegistry;
     private Stack<String> processing;
     private String inputPrefix = DEFAULT_INPUT_PREFIX;
-    private String inputPostfix = DEFAULT_INPUT_POSTFIX;
+    private String inputSuffix = DEFAULT_INPUT_SUFFIX;
 
     public Map<String, GraphQLDirective> getDirectiveRegistry() {
         return directiveRegistry;
@@ -114,11 +114,11 @@ public class ProcessingElementsContainer {
         this.inputPrefix = inputPrefix;
     }
 
-    public String getInputPostfix() {
-        return inputPostfix;
+    public String getInputSuffix() {
+        return inputSuffix;
     }
 
-    public void setInputPostfix(String inputPostfix) {
-        this.inputPostfix = inputPostfix;
+    public void setInputSuffix(String inputSuffix) {
+        this.inputSuffix = inputSuffix;
     }
 }

--- a/src/main/java/graphql/annotations/processor/ProcessingElementsContainer.java
+++ b/src/main/java/graphql/annotations/processor/ProcessingElementsContainer.java
@@ -27,6 +27,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.Stack;
 
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_POSTFIX;
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
+
 public class ProcessingElementsContainer {
 
     private TypeFunction defaultTypeFunction;
@@ -35,6 +38,8 @@ public class ProcessingElementsContainer {
     private Map<String, graphql.schema.GraphQLDirective> directiveRegistry;
     private Map<Class<?>, Set<Class<?>>> extensionsTypeRegistry;
     private Stack<String> processing;
+    private String inputPrefix = DEFAULT_INPUT_PREFIX;
+    private String inputPostfix = DEFAULT_INPUT_POSTFIX;
 
     public Map<String, GraphQLDirective> getDirectiveRegistry() {
         return directiveRegistry;
@@ -99,5 +104,21 @@ public class ProcessingElementsContainer {
 
     public void setProcessing(Stack<String> processing) {
         this.processing = processing;
+    }
+
+    public String getInputPrefix() {
+        return inputPrefix;
+    }
+
+    public void setInputPrefix(String inputPrefix) {
+        this.inputPrefix = inputPrefix;
+    }
+
+    public String getInputPostfix() {
+        return inputPostfix;
+    }
+
+    public void setInputPostfix(String inputPostfix) {
+        this.inputPostfix = inputPostfix;
     }
 }

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
@@ -26,8 +26,6 @@ import graphql.annotations.processor.typeBuilders.*;
 import graphql.schema.*;
 import org.osgi.service.component.annotations.*;
 
-import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
-
 @Component(service = GraphQLTypeRetriever.class, immediate = true)
 public class GraphQLTypeRetriever {
 
@@ -62,7 +60,7 @@ public class GraphQLTypeRetriever {
         GraphQLType type;
 
         if (isInput) {
-            typeName = container.getInputPrefix() + typeName + container.getInputPostfix();
+            typeName = container.getInputPrefix() + typeName + container.getInputSuffix();
         }
 
         if (container.getProcessing().contains(typeName)) {

--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLTypeRetriever.java
@@ -48,6 +48,7 @@ public class GraphQLTypeRetriever {
      *
      * @param object    the object class to examine*
      * @param container a class that hold several members that are required in order to build schema
+     * @param isInput true if the type is an input type, false otherwise
      * @return a {@link GraphQLType} that represents that object class
      * @throws graphql.annotations.processor.exceptions.GraphQLAnnotationsException if the object class cannot be examined
      * @throws graphql.annotations.processor.exceptions.CannotCastMemberException   if the object class cannot be examined
@@ -61,7 +62,7 @@ public class GraphQLTypeRetriever {
         GraphQLType type;
 
         if (isInput) {
-            typeName = DEFAULT_INPUT_PREFIX + typeName;
+            typeName = container.getInputPrefix() + typeName + container.getInputPostfix();
         }
 
         if (container.getProcessing().contains(typeName)) {

--- a/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
@@ -29,7 +29,6 @@ import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.List;
 
-import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
 import static graphql.annotations.processor.util.ObjectUtil.getAllFields;
 
 public class InputObjectBuilder {
@@ -56,7 +55,7 @@ public class InputObjectBuilder {
 
     public GraphQLInputObjectType.Builder getInputObjectBuilder(Class<?> object, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLInputObjectType.Builder builder = GraphQLInputObjectType.newInputObject();
-        builder.name(container.getInputPrefix() + graphQLObjectInfoRetriever.getTypeName(object) + container.getInputPostfix());
+        builder.name(container.getInputPrefix() + graphQLObjectInfoRetriever.getTypeName(object) + container.getInputSuffix());
         GraphQLDescription description = object.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());

--- a/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
+++ b/src/main/java/graphql/annotations/processor/typeBuilders/InputObjectBuilder.java
@@ -56,7 +56,7 @@ public class InputObjectBuilder {
 
     public GraphQLInputObjectType.Builder getInputObjectBuilder(Class<?> object, ProcessingElementsContainer container) throws GraphQLAnnotationsException {
         GraphQLInputObjectType.Builder builder = GraphQLInputObjectType.newInputObject();
-        builder.name(DEFAULT_INPUT_PREFIX + graphQLObjectInfoRetriever.getTypeName(object));
+        builder.name(container.getInputPrefix() + graphQLObjectInfoRetriever.getTypeName(object) + container.getInputPostfix());
         GraphQLDescription description = object.getAnnotation(GraphQLDescription.class);
         if (description != null) {
             builder.description(description.value());

--- a/src/main/java/graphql/annotations/processor/util/InputPropertiesUtil.java
+++ b/src/main/java/graphql/annotations/processor/util/InputPropertiesUtil.java
@@ -16,5 +16,5 @@ package graphql.annotations.processor.util;
 
 public class InputPropertiesUtil {
     public static final String DEFAULT_INPUT_PREFIX = "Input";
-    public static final String DEFAULT_INPUT_POSTFIX = "";
+    public static final String DEFAULT_INPUT_SUFFIX = "";
 }

--- a/src/main/java/graphql/annotations/processor/util/InputPropertiesUtil.java
+++ b/src/main/java/graphql/annotations/processor/util/InputPropertiesUtil.java
@@ -16,4 +16,5 @@ package graphql.annotations.processor.util;
 
 public class InputPropertiesUtil {
     public static final String DEFAULT_INPUT_PREFIX = "Input";
+    public static final String DEFAULT_INPUT_POSTFIX = "";
 }

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -40,6 +40,8 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import static graphql.Scalars.GraphQLString;
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_POSTFIX;
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLSchema.newSchema;
 import static org.testng.Assert.*;
@@ -724,7 +726,24 @@ public class GraphQLObjectTest {
                 new BreadthFirstSearch(graphQLObjectInfoRetriever), new GraphQLFieldRetriever()).
                 getInputObjectBuilder(InputObject.class, GraphQLAnnotations.getInstance().getContainer()).build();
 
+        assertEquals(type.getName(), DEFAULT_INPUT_PREFIX + InputObject.class.getSimpleName(), "Type name prefix did not match expected value");
         assertEquals(type.getFields().size(), InputObject.class.getDeclaredFields().length);
+    }
+
+    @Test
+    public void inputObjectCustomPrefixes() {
+        GraphQLObjectInfoRetriever graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
+        ProcessingElementsContainer container = GraphQLAnnotations.getInstance().getContainer();
+        container.setInputPrefix("");
+        container.setInputPostfix("Input");
+        GraphQLInputObjectType type = new InputObjectBuilder(graphQLObjectInfoRetriever, new ParentalSearch(graphQLObjectInfoRetriever),
+                new BreadthFirstSearch(graphQLObjectInfoRetriever), new GraphQLFieldRetriever()).
+                getInputObjectBuilder(InputObject.class, GraphQLAnnotations.getInstance().getContainer()).build();
+
+        assertEquals(type.getName(), "" + InputObject.class.getSimpleName() + "Input", "Type name prefix did not match expected value");
+        assertEquals(type.getFields().size(), InputObject.class.getDeclaredFields().length);
+        container.setInputPrefix(DEFAULT_INPUT_PREFIX);
+        container.setInputPostfix(DEFAULT_INPUT_POSTFIX);
     }
 
     public static class UUIDTypeFunction implements TypeFunction {

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -40,7 +40,7 @@ import java.util.*;
 import java.util.function.Supplier;
 
 import static graphql.Scalars.GraphQLString;
-import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_POSTFIX;
+import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_SUFFIX;
 import static graphql.annotations.processor.util.InputPropertiesUtil.DEFAULT_INPUT_PREFIX;
 import static graphql.schema.GraphQLFieldDefinition.newFieldDefinition;
 import static graphql.schema.GraphQLSchema.newSchema;
@@ -735,7 +735,7 @@ public class GraphQLObjectTest {
         GraphQLObjectInfoRetriever graphQLObjectInfoRetriever = new GraphQLObjectInfoRetriever();
         ProcessingElementsContainer container = GraphQLAnnotations.getInstance().getContainer();
         container.setInputPrefix("");
-        container.setInputPostfix("Input");
+        container.setInputSuffix("Input");
         GraphQLInputObjectType type = new InputObjectBuilder(graphQLObjectInfoRetriever, new ParentalSearch(graphQLObjectInfoRetriever),
                 new BreadthFirstSearch(graphQLObjectInfoRetriever), new GraphQLFieldRetriever()).
                 getInputObjectBuilder(InputObject.class, GraphQLAnnotations.getInstance().getContainer()).build();
@@ -743,7 +743,7 @@ public class GraphQLObjectTest {
         assertEquals(type.getName(), "" + InputObject.class.getSimpleName() + "Input", "Type name prefix did not match expected value");
         assertEquals(type.getFields().size(), InputObject.class.getDeclaredFields().length);
         container.setInputPrefix(DEFAULT_INPUT_PREFIX);
-        container.setInputPostfix(DEFAULT_INPUT_POSTFIX);
+        container.setInputSuffix(DEFAULT_INPUT_SUFFIX);
     }
 
     public static class UUIDTypeFunction implements TypeFunction {


### PR DESCRIPTION
Make it possible to provide custom prefixes AND postfixes for input object name generation. This is setup on the container.

The defaults were not changed and are equivalent to :
container.setInputPrefix("Input");
container.setInputPostfix("";

If you want to change the naming generation to something more "compliant" with GraphQL's naming conventions you can change the configuration to:

container.setInputPrefix("");
container.setInputPostfix("Input");

So for example, if generating a name for the input type generated from the class Books it will be called InputBooks in the first configuration and BooksInput in the second configuration. This is also very useful if you are using prefixes to namespace your classes. For example, ACMEBooks will be InputACMEBooks in the first configuration and ACMEBooksInput in the second configuration.

As you can see the prefix and postfix configuration is also very flexible and the "Input" word is just a configuration variable now.

By default, however, nothing changes so existing projects should not break.

Some unit tests were also added to make sure that the generation works properly.

Please don't hesitate if you have any questions or comments about this PR, I will do my best to answer swiftly.