### PR TITLE
Add support for graphql-java v11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
-    compile 'com.graphql-java:graphql-java:9.2'
+    compile 'com.graphql-java:graphql-java:11.0'
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'

--- a/src/main/java/graphql/annotations/connection/PaginatedDataConnectionFetcher.java
+++ b/src/main/java/graphql/annotations/connection/PaginatedDataConnectionFetcher.java
@@ -41,7 +41,7 @@ public class PaginatedDataConnectionFetcher<T> implements ConnectionFetcher<T> {
     }
 
     @Override
-    public Connection<T> get(DataFetchingEnvironment environment) {
+    public Connection<T> get(DataFetchingEnvironment environment) throws Exception {
         PaginatedData<T> paginatedData = paginationDataFetcher.get(environment);
         if (paginatedData == null) {
             return new DefaultConnection<>(Collections.emptyList(), new DefaultPageInfo(null,null,false,false));

--- a/src/main/java/graphql/annotations/connection/simple/SimpleConnectionDataFetcher.java
+++ b/src/main/java/graphql/annotations/connection/simple/SimpleConnectionDataFetcher.java
@@ -44,7 +44,7 @@ public class SimpleConnectionDataFetcher<T> implements SimpleConnectionFetcher<T
     }
 
     @Override
-    public Connection<T> get(DataFetchingEnvironment environment) {
+    public Connection<T> get(DataFetchingEnvironment environment) throws Exception {
         SimpleConnectionFetcher<T> conn = constructNewInstance(constructor, actualDataFetcher);
         return conn.get(environment);
     }

--- a/src/main/java/graphql/annotations/connection/simple/SimplePaginatedDataConnectionFetcher.java
+++ b/src/main/java/graphql/annotations/connection/simple/SimplePaginatedDataConnectionFetcher.java
@@ -26,7 +26,7 @@ public class SimplePaginatedDataConnectionFetcher<T> implements SimpleConnection
     }
 
     @Override
-    public SimpleConnection<T> get(DataFetchingEnvironment environment) {
+    public SimpleConnection<T> get(DataFetchingEnvironment environment) throws Exception {
         return simplePaginatedDataDataFetcher.get(environment);
     }
 }

--- a/src/main/java/graphql/annotations/dataFetchers/ExtensionDataFetcherWrapper.java
+++ b/src/main/java/graphql/annotations/dataFetchers/ExtensionDataFetcherWrapper.java
@@ -34,7 +34,7 @@ public class ExtensionDataFetcherWrapper<T> implements DataFetcher<T> {
     }
 
     @Override
-    public T get(DataFetchingEnvironment environment) {
+    public T get(DataFetchingEnvironment environment) throws Exception {
         Object source = environment.getSource();
         if (source != null && (!declaringClass.isInstance(source)) && !(source instanceof Map)) {
             environment = new DataFetchingEnvironmentImpl(newInstance(declaringClass, source),
@@ -43,7 +43,7 @@ public class ExtensionDataFetcherWrapper<T> implements DataFetcher<T> {
                     environment.getFields(), environment.getFieldType(), environment.getParentType(),
                     environment.getGraphQLSchema(),
                     environment.getFragmentsByName(), environment.getExecutionId(),
-                    environment.getSelectionSet(), environment.getFieldTypeInfo(),
+                    environment.getSelectionSet(), environment.getExecutionStepInfo(),
                     environment.getExecutionContext());
         }
 

--- a/src/main/java/graphql/annotations/dataFetchers/connection/AsyncConnectionDataFetcher.java
+++ b/src/main/java/graphql/annotations/dataFetchers/connection/AsyncConnectionDataFetcher.java
@@ -30,7 +30,13 @@ public class AsyncConnectionDataFetcher<T> implements DataFetcher<CompletableFut
     }
 
     @Override
-    public CompletableFuture<graphql.relay.Connection<T>> get(DataFetchingEnvironment environment) {
-        return supplyAsync(() -> connectionDataFetcher.get(environment));
+    public CompletableFuture<graphql.relay.Connection<T>> get(DataFetchingEnvironment environment) throws Exception {
+        return supplyAsync(() -> {
+            try {
+                return connectionDataFetcher.get(environment);
+            } catch (Exception e) {
+                throw new RuntimeException("Error in AsyncConnectionDataFetcher", e);
+            }
+        });
     }
 }

--- a/src/main/java/graphql/annotations/dataFetchers/connection/ConnectionDataFetcher.java
+++ b/src/main/java/graphql/annotations/dataFetchers/connection/ConnectionDataFetcher.java
@@ -44,7 +44,7 @@ public class ConnectionDataFetcher<T> implements DataFetcher<graphql.relay.Conne
     }
 
     @Override
-    public graphql.relay.Connection<T> get(DataFetchingEnvironment environment) {
+    public graphql.relay.Connection<T> get(DataFetchingEnvironment environment) throws Exception {
         ConnectionFetcher<T> conn = constructNewInstance(constructor, actualDataFetcher);
         return conn.get(environment);
     }

--- a/src/main/java/graphql/annotations/dataFetchers/connection/DispatchingConnection.java
+++ b/src/main/java/graphql/annotations/dataFetchers/connection/DispatchingConnection.java
@@ -34,7 +34,7 @@ public class DispatchingConnection implements DataFetcher, Connection {
     }
 
     @Override
-    public Object get(DataFetchingEnvironment environment) {
+    public Object get(DataFetchingEnvironment environment) throws Exception {
         return connection.get(environment);
     }
 }

--- a/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
+++ b/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
@@ -31,7 +31,7 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
 
     @Override
     protected CompletableFuture<ExecutionResult> resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getTypeInfo().getType();
+        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, parameters.getField().get(0));
         if (fieldDef == null) return null;
 
@@ -52,12 +52,12 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
                 clientMutationId = clientMutationIdVal.getValue();
             }
 
-            ExecutionTypeInfo fieldTypeInfo = ExecutionTypeInfo.newTypeInfo().type(fieldDef.getType()).parentInfo(parameters.getTypeInfo()).build();
+            ExecutionStepInfo fieldTypeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldDef.getType()).parentInfo(parameters.getExecutionStepInfo()).build();
             ExecutionStrategyParameters newParameters = ExecutionStrategyParameters.newParameters()
                     .arguments(parameters.getArguments())
                     .fields(parameters.getFields())
                     .nonNullFieldValidator(parameters.getNonNullFieldValidator())
-                    .typeInfo(fieldTypeInfo)
+                    .executionStepInfo(fieldTypeInfo)
                     .source(clientMutationId)
                     .build();
 
@@ -70,7 +70,7 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
 
     @Override
     protected FieldValueInfo completeValue(ExecutionContext executionContext, ExecutionStrategyParameters parameters) throws NonNullableFieldWasNullException {
-        graphql.schema.GraphQLType fieldType = parameters.getTypeInfo().getType();
+        graphql.schema.GraphQLType fieldType = parameters.getExecutionStepInfo().getType();
         Object result = parameters.getSource();
         if (result instanceof Enum && fieldType instanceof GraphQLEnumType) {
             Object value = ((GraphQLEnumType) fieldType).getCoercing().parseValue(((Enum) result).name());
@@ -91,7 +91,7 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
                 .arguments(parameters.getArguments())
                 .fields(parameters.getFields())
                 .nonNullFieldValidator(parameters.getNonNullFieldValidator())
-                .typeInfo(parameters.getTypeInfo())
+                .executionStepInfo(parameters.getExecutionStepInfo())
                 .source(source)
                 .build();
     }


### PR DESCRIPTION
Here is an update to migrate to graphql-java 11. I didn't have much time to test but all the unit tests seems to run.

The main point that needs review is the changes in the AsyncConnectionDataFetcher as I'm not an expert with the CompletableFutures
