### PR TITLE
Switch from getType() to getUnwrappedNonNullType() in EnhancedExecutionStrategy 

### DIFF
--- a/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
+++ b/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
@@ -31,7 +31,7 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
 
     @Override
     protected CompletableFuture<ExecutionResult> resolveField(ExecutionContext executionContext, ExecutionStrategyParameters parameters) {
-        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getType();
+        GraphQLObjectType parentType = (GraphQLObjectType) parameters.getExecutionStepInfo().getUnwrappedNonNullType();
         GraphQLFieldDefinition fieldDef = getFieldDef(executionContext.getGraphQLSchema(), parentType, parameters.getField().get(0));
         if (fieldDef == null) return null;
 


### PR DESCRIPTION
A ClassCastException was being thrown when executing the standard introspection query to retrieve the GraphQL schema. In the release notes for graphql-java 11.0, in the Breaking Changes section, there was the following comment: "If you used .getType() please change it to .getUnwrappedNonNullType() to avoid any logic changes." I switched EnhancedExecutionStrategy to utilize getUnwrappedNonNullType() and that appears to have taken care of the issue.

```
Caused by: java.lang.ClassCastException: graphql.schema.GraphQLNonNull cannot be cast to graphql.schema.GraphQLObjectType
	at graphql.annotations.strategies.EnhancedExecutionStrategy.resolveField(EnhancedExecutionStrategy.java:34)
	at graphql.execution.AsyncSerialExecutionStrategy.lambda$execute$1(AsyncSerialExecutionStrategy.java:43)
	at graphql.execution.Async.eachSequentiallyImpl(Async.java:75)
	at graphql.execution.Async.eachSequentially(Async.java:64)
	at graphql.execution.AsyncSerialExecutionStrategy.execute(AsyncSerialExecutionStrategy.java:38)
	at graphql.execution.ExecutionStrategy.completeValueForObject(ExecutionStrategy.java:636)
	at graphql.execution.ExecutionStrategy.completeValue(ExecutionStrategy.java:416)
	at graphql.annotations.strategies.EnhancedExecutionStrategy.completeValue(EnhancedExecutionStrategy.java:83)
	at graphql.execution.ExecutionStrategy.completeField(ExecutionStrategy.java:366)
	at graphql.execution.ExecutionStrategy.lambda$resolveFieldWithInfo$0(ExecutionStrategy.java:204)
(etc.)
```