### PR TITLE
Remove static method to use the current instance

### DIFF
--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
@@ -42,7 +42,7 @@ public class GraphQLObjectInfoRetriever {
                 .collect(Collectors.toList());
     }
 
-    public static Boolean isGraphQLField(AnnotatedElement element) {
+    public Boolean isGraphQLField(AnnotatedElement element) {
         GraphQLField annotation = element.getAnnotation(GraphQLField.class);
         if (annotation == null) {
             return null;


### PR DESCRIPTION
I think* that this doesn't need to be static and, right now, is prohibiting overrides of the method for classes that extend GraphQLObjectInfoRetriever.

Thank you for your library, nice work :)