### PR TITLE
Set correct version for annotations in README.MD

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ dependencies {
 <dependency>
     <groupId>io.github.graphql-java</groupId>
     <artifactId>graphql-java-annotations</artifactId>
-    <version>7.0</version>
+    <version>7.0.1</version>
 </dependency>
 ```
 


### PR DESCRIPTION
Minor adjustment to the maven part of the readme to match the newest version of graphql-java-annotations.

Could you also tag this release please :)