### PR TITLE
Fixing GraphQLDeprecate not showing in graphiql

### DIFF
--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilder.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -30,7 +30,7 @@ public class DeprecateBuilder implements Builder<String> {
     public String build() {
         GraphQLDeprecate deprecate = object.getAnnotation(GraphQLDeprecate.class);
         if (deprecate != null) {
-            return deprecate.value();
+            return deprecate.value().isEmpty() ? DEFAULT_DEPRECATION_DESCRIPTION : deprecate.value();
         }
         if (object.getAnnotation(Deprecated.class) != null) {
             return DEFAULT_DEPRECATION_DESCRIPTION;

--- a/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilderTest.java
+++ b/src/test/java/graphql/annotations/processor/retrievers/fieldBuilders/DeprecateBuilderTest.java
@@ -67,7 +67,7 @@ public class DeprecateBuilderTest {
         String deprecate = deprecateBuilder.build();
 
         // assert
-        assertEquals(deprecate, "");
+        assertEquals(deprecate, "Deprecated");
     }
 
     @Test


### PR DESCRIPTION
When someone uses ``@GraphQLDeprecate`` without supplying a reason, it passes an empty string, which graphiql for some reason does not parse and treats the field as a non-deprecated field.
So now the default value is ``Deprecated`` even if no reason been supplied to the annotation (same as ``@Deprecated`` annotation)

fixing https://github.com/Enigmatis/graphql-java-annotations/issues/210