### PR TITLE
Support new directives way in the schema creator

### DIFF
--- a/README.md
+++ b/README.md
@@ -438,7 +438,7 @@ In order to define a default value for the argument, use the `default` keyword l
 
 After you created the class, you will be able to create the ``GraphQLDirective`` object using the following code:
 ```java
-GraphQLDirective directive = graphqlAnnotations.directiveViaAnnotation(Suffix.class);
+GraphQLDirective directive = graphqlAnnotations.directive(Suffix.class);
 ```
 
 #### Using a method declaration

--- a/src/main/java/graphql/annotations/processor/GraphQLAnnotations.java
+++ b/src/main/java/graphql/annotations/processor/GraphQLAnnotations.java
@@ -34,7 +34,6 @@ import graphql.schema.GraphQLDirective;
 import graphql.schema.GraphQLInterfaceType;
 import graphql.schema.GraphQLObjectType;
 
-import java.lang.annotation.Retention;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -159,21 +158,9 @@ public class GraphQLAnnotations implements GraphQLAnnotationsProcessor {
         }
     }
 
+    @Deprecated
     public GraphQLDirective directiveViaAnnotation(Class<?> annotationClass) {
-        if (!annotationClass.isAnnotationPresent(GraphQLDirectiveDefinition.class) || !annotationClass.isAnnotationPresent(Retention.class)){
-            throw new GraphQLAnnotationsException(String.format("The supplied class %s is not annotated with a GraphQLDirectiveDefinition and/or Retention annotation", annotationClass.getSimpleName()), null);
-        }
-
-        try {
-            GraphQLDirective directive = this.directiveCreator.getDirective(annotationClass);
-            GraphQLDirectiveDefinition annotation = annotationClass.getAnnotation(GraphQLDirectiveDefinition.class);
-            this.getContainer().getDirectiveRegistry().put(directive.getName(), new DirectiveAndWiring(directive, annotation.wiring()));
-            return directive;
-        } catch (GraphQLAnnotationsException e) {
-            this.getContainer().getProcessing().clear();
-            this.getTypeRegistry().clear();
-            throw e;
-        }
+        return this.directive(annotationClass);
     }
 
     public Set<GraphQLDirective> directives(Class<?> directivesDeclarationClass) {

--- a/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
+++ b/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
+++ b/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
@@ -1,12 +1,12 @@
 /**
  * Copyright 2016 Yurii Rashkovskii
- *
+ * <p>
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -17,10 +17,10 @@ package graphql.annotations;
 import graphql.annotations.annotationTypes.GraphQLDescription;
 import graphql.annotations.annotationTypes.GraphQLField;
 import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.annotationTypes.directives.definition.DirectiveLocations;
 import graphql.annotations.annotationTypes.directives.definition.GraphQLDirectiveDefinition;
 import graphql.annotations.directives.AnnotationsDirectiveWiring;
 import graphql.annotations.directives.AnnotationsWiringEnvironment;
-import graphql.annotations.annotationTypes.directives.definition.DirectiveLocations;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.introspection.Introspection;
 import graphql.schema.GraphQLDirective;
@@ -30,6 +30,10 @@ import graphql.schema.GraphQLSchema;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -110,7 +114,7 @@ public class AnnotationsSchemaCreatorTest {
         assertThat(subscriptionType.getFieldDefinitions().size(), is(1));
     }
 
-    public static class GeneralWiring implements AnnotationsDirectiveWiring{
+    public static class GeneralWiring implements AnnotationsDirectiveWiring {
         @Override
         public GraphQLFieldDefinition onField(AnnotationsWiringEnvironment environment) {
             return null;
@@ -156,6 +160,62 @@ public class AnnotationsSchemaCreatorTest {
         // assert
         assertThat(schema.getDirective("secondDirective"), notNullValue());
         assertThat(schema.getDirective("testDirective"), notNullValue());
+    }
+
+
+    @GraphQLDirectiveDefinition(wiring = GeneralWiring.class)
+    @GraphQLName("upper")
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    @DirectiveLocations(Introspection.DirectiveLocation.FIELD_DEFINITION)
+    @interface UpperAnnotation {
+        boolean isActive() default true;
+    }
+
+
+    @Test
+    public void build_directiveUsingAnnotation_schemaIsCreatedWithDirective() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest.class).directive(UpperAnnotation.class).build();
+
+        // assert
+        GraphQLDirective testDirective = schema.getDirective("upper");
+        assertThat(testDirective, notNullValue());
+        assertThat(testDirective.getArguments().size(), is(1));
+        assertThat(testDirective.getArgument("isActive"), notNullValue());
+    }
+
+
+    public static class DirectivesContainer {
+        @GraphQLName("suffix")
+        @GraphQLDirectiveDefinition(wiring = GeneralWiring.class)
+        @DirectiveLocations({Introspection.DirectiveLocation.FIELD_DEFINITION, Introspection.DirectiveLocation.ARGUMENT_DEFINITION})
+        public static void suffixDirective(@GraphQLName("suffix") String suffix) {
+
+        }
+
+        @GraphQLName("upper")
+        @GraphQLDirectiveDefinition(wiring = GeneralWiring.class)
+        @DirectiveLocations({Introspection.DirectiveLocation.FIELD_DEFINITION, Introspection.DirectiveLocation.ARGUMENT_DEFINITION})
+        public static void upper() {
+
+        }
+    }
+
+
+    @Test
+    public void build_directive_UsingDirectivesContainer_schemaIsCreatedWithDirective() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest.class).directives(DirectivesContainer.class).build();
+
+        // assert
+        GraphQLDirective testDirective = schema.getDirective("suffix");
+        assertThat(testDirective, notNullValue());
+        assertThat(testDirective.getArguments().size(), is(1));
+        assertThat(testDirective.getArgument("suffix"), notNullValue());
+
+        GraphQLDirective upper = schema.getDirective("upper");
+        assertThat(upper, notNullValue());
     }
 
     @GraphQLName("additional")

--- a/src/test/java/graphql/annotations/GraphQLDirectiveCreationTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDirectiveCreationTest.java
@@ -15,10 +15,10 @@
 package graphql.annotations;
 
 import graphql.annotations.annotationTypes.GraphQLDescription;
-import graphql.annotations.annotationTypes.directives.definition.GraphQLDirectiveDefinition;
 import graphql.annotations.annotationTypes.GraphQLName;
-import graphql.annotations.directives.AnnotationsDirectiveWiring;
 import graphql.annotations.annotationTypes.directives.definition.DirectiveLocations;
+import graphql.annotations.annotationTypes.directives.definition.GraphQLDirectiveDefinition;
+import graphql.annotations.directives.AnnotationsDirectiveWiring;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.introspection.Introspection;
@@ -171,7 +171,7 @@ public class GraphQLDirectiveCreationTest {
     @Test
     public void directive_suppliedDirectiveAnnotation_returnCorrectDirective() {
         // Act
-        GraphQLDirective upper = this.graphQLAnnotations.directiveViaAnnotation(UpperAnnotation.class);
+        GraphQLDirective upper = this.graphQLAnnotations.directive(UpperAnnotation.class);
 
         // Assert
         assertEquals(upper.getName(), "upper");
@@ -188,7 +188,7 @@ public class GraphQLDirectiveCreationTest {
     @Test(expectedExceptions = GraphQLAnnotationsException.class)
     public void directive_suppliedNoDirectiveAnnotation_throwException() {
         // Act
-        GraphQLDirective upper = this.graphQLAnnotations.directiveViaAnnotation(NoDirectiveAnnotation.class);
+        GraphQLDirective upper = this.graphQLAnnotations.directive(NoDirectiveAnnotation.class);
     }
 
 

--- a/src/test/java/graphql/annotations/GraphQLDirectivesViaAnnotationDefinitionTest.java
+++ b/src/test/java/graphql/annotations/GraphQLDirectivesViaAnnotationDefinitionTest.java
@@ -46,9 +46,9 @@ public class GraphQLDirectivesViaAnnotationDefinitionTest {
     @BeforeMethod
     public void setUp() {
         this.graphQLAnnotations = new GraphQLAnnotations();
-        this.graphQLAnnotations.directiveViaAnnotation(Upper.class);
-        this.graphQLAnnotations.directiveViaAnnotation(Suffix.class);
-        this.graphQLAnnotations.directiveViaAnnotation(DirectiveWithList.class);
+        this.graphQLAnnotations.directive(Upper.class);
+        this.graphQLAnnotations.directive(Suffix.class);
+        this.graphQLAnnotations.directive(DirectiveWithList.class);
         GraphQLObjectType object = this.graphQLAnnotations.object(Query.class);
         GraphQLCodeRegistry codeRegistry = graphQLAnnotations.getContainer().getCodeRegistryBuilder().build();
         this.schema = newSchema().query(object).codeRegistry(codeRegistry).build();


### PR DESCRIPTION
In 7.2 the new ways of creating directives (via methods & annotations) was not yet supported.
This PR adds support in the `AnnotationsSchemaCreator`. It also adds tests and deprecating the ``directiveViaAnnotation`` method in the processor, because ``directive`` method does the same logic.