### PR TITLE
Updating to use latest graphql-java:16.2 library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
-    compile 'com.graphql-java:graphql-java:15.0'
+    compile 'com.graphql-java:graphql-java:16.2'
 
     // OSGi
     compileOnly 'org.osgi:org.osgi.core:6.0.0'

--- a/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
+++ b/src/main/java/graphql/annotations/strategies/EnhancedExecutionStrategy.java
@@ -54,7 +54,6 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
 
             ExecutionStepInfo fieldTypeInfo = ExecutionStepInfo.newExecutionStepInfo().type(fieldDef.getType()).parentInfo(parameters.getExecutionStepInfo()).build();
             ExecutionStrategyParameters newParameters = ExecutionStrategyParameters.newParameters()
-                    .arguments(parameters.getArguments())
                     .fields(parameters.getFields())
                     .nonNullFieldValidator(parameters.getNonNullFieldValidator())
                     .executionStepInfo(fieldTypeInfo)
@@ -88,7 +87,6 @@ public class EnhancedExecutionStrategy extends AsyncSerialExecutionStrategy {
      */
     private ExecutionStrategyParameters withSource(ExecutionStrategyParameters parameters, Object source) {
         return ExecutionStrategyParameters.newParameters()
-                .arguments(parameters.getArguments())
                 .fields(parameters.getFields())
                 .nonNullFieldValidator(parameters.getNonNullFieldValidator())
                 .executionStepInfo(parameters.getExecutionStepInfo())

--- a/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
+++ b/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
@@ -220,6 +220,7 @@ public class AnnotationsSchemaCreatorTest {
 
     @GraphQLName("additional")
     public static class AdditionalTypeTest {
+        @GraphQLField
         public int getI() {
             return 4;
         }

--- a/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
+++ b/src/test/java/graphql/annotations/GraphQLExtensionsTest.java
@@ -20,6 +20,7 @@ import graphql.annotations.annotationTypes.*;
 import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
 import graphql.annotations.processor.retrievers.GraphQLObjectHandler;
+import graphql.com.google.common.collect.ImmutableList;
 import graphql.schema.*;
 import org.testng.annotations.Test;
 
@@ -103,7 +104,7 @@ public class GraphQLExtensionsTest {
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 5);
 
-        fields.sort(Comparator.comparing(GraphQLFieldDefinition::getName));
+        fields = ImmutableList.sortedCopyOf(Comparator.comparing(GraphQLFieldDefinition::getName), fields);
 
         assertEquals(fields.get(0).getName(), "field");
         assertEquals(fields.get(1).getName(), "field2");

--- a/src/test/java/graphql/annotations/GraphQLObjectTest.java
+++ b/src/test/java/graphql/annotations/GraphQLObjectTest.java
@@ -28,6 +28,7 @@ import graphql.annotations.processor.searchAlgorithms.ParentalSearch;
 import graphql.annotations.processor.typeBuilders.InputObjectBuilder;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.annotations.processor.util.CodeRegistryUtil;
+import graphql.com.google.common.collect.ImmutableList;
 import graphql.schema.*;
 import graphql.schema.GraphQLType;
 import graphql.schema.idl.SchemaParser;
@@ -275,7 +276,7 @@ public class GraphQLObjectTest {
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 8);
 
-        fields.sort((o1, o2) -> o1.getName().compareTo(o2.getName()));
+        fields = ImmutableList.sortedCopyOf((o1, o2) -> o1.getName().compareTo(o2.getName()), fields);
 
         assertEquals(fields.get(2).getName(), "field0");
         assertEquals(fields.get(2).getDescription(), "field");
@@ -407,7 +408,7 @@ public class GraphQLObjectTest {
         GraphQLObjectType object = this.graphQLAnnotations.object(TestAccessors.class);
         List<GraphQLFieldDefinition> fields = object.getFieldDefinitions();
         assertEquals(fields.size(), 2);
-        fields.sort(Comparator.comparing(GraphQLFieldDefinition::getName));
+        fields = ImmutableList.sortedCopyOf(Comparator.comparing(GraphQLFieldDefinition::getName), fields);
 
         assertEquals(fields.get(0).getName(), "getValue");
         assertEquals(fields.get(1).getName(), "setAnotherValue");


### PR DESCRIPTION
* Fixed test to include a field because validation in graphql-java now requires types to have one or more fields ( https://github.com/graphql-java/graphql-java/pull/1955 )
* Removed references to arguments when recreating ExecutionStrategyParameters because arguments field was dropped in graphql-java ( https://github.com/graphql-java/graphql-java/pull/2023/files#diff-d31b54bc13a6051c43027e76627c6e99de28f64adfcfcfb275856ec00890cc4fL44 )
* Updated tests to work with immutable structures that graphql-java has moved to ( https://github.com/graphql-java/graphql-java/pull/2086/files#diff-9fed7fa709720e6a47a80119bb991def6fa752f8933d9f5e3dfcede5520c07d6R134 )