### PR TITLE
Fix for issue#283 Renamed bundle.bnd to bnd.bnd to generate OSGi Metadata properly

### DIFF
--- a/bundle.bnd
+++ b/bundle.bnd
@@ -1,3 +1,0 @@
-Export-Package: graphql.annotations.*;version="3.0.3"
-Bundle-SymbolicName: graphql.annotations
--nouses=true


### PR DESCRIPTION
I've simply renamed the bundle.bnd to bnd.bnd so that the new version of the BND gradle plugin picks up the BND configuration correctly. This seems to generate the proper OSGi Metadata. 