### PR TITLE
Upgrade graphql-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -54,7 +54,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     compile 'javax.validation:validation-api:1.1.0.Final'
-    compile 'com.graphql-java:graphql-java:17.2'
+    compile 'com.graphql-java:graphql-java:17.4'
     compile 'com.graphql-java:graphql-java-extended-scalars:17.0'
 
 


### PR DESCRIPTION
Bump graphql-java from 17.2 to 17.4. This will fix graphql-java vulnerability issue reported by Synk [SNYK-JAVA-COMGRAPHQLJAVA-3021519](https://security.snyk.io/vuln/SNYK-JAVA-COMGRAPHQLJAVA-3021519)