### PR TITLE
Let ID be every type, since it is allowed by

### DIFF
--- a/src/main/java/graphql/annotations/processor/typeFunctions/IDFunction.java
+++ b/src/main/java/graphql/annotations/processor/typeFunctions/IDFunction.java
@@ -30,9 +30,7 @@ class IDFunction implements TypeFunction {
 
     @Override
     public boolean canBuildType(Class<?> aClass, AnnotatedType annotatedType) {
-        return annotatedType != null
-                && (aClass == Integer.class || aClass == int.class || aClass == String.class)
-                && annotatedType.isAnnotationPresent(GraphQLID.class);
+        return annotatedType != null && annotatedType.isAnnotationPresent(GraphQLID.class);
     }
 
     @Override


### PR DESCRIPTION
According to https://graphql.org/learn/schema/#scalar-types the ID type can be any type that can be represented by a string, not just a int/Integer/String. For example a Long is a common scalar that can be used for an ID and is perfectly allowed.