### PR TITLE
Add Bnd instructions

### DIFF
--- a/bnd.bnd
+++ b/bnd.bnd
@@ -1,0 +1,2 @@
+-exportcontents: graphql.annotations.*
+-nouses: true

--- a/build.gradle
+++ b/build.gradle
@@ -165,9 +165,6 @@ signing {
 
 tasks.register('bundle', Bundle) {
     from sourceSets.main.output
-    bundle {
-        bndfile = project.file('bundle.bnd')
-    }
 }
 
 wrapper {


### PR DESCRIPTION
Without the Bnd instructions, the created OSGi manifest does not export any packages.

I added no uses because it was part of the old `bundle.bnd` file.