### PR TITLE
Upgrade graphql-java version to 21.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you would like to use a tool that creates a graphql spring boot server using 
 
 ```groovy
 dependencies {
-  compile "io.github.graphql-java:graphql-java-annotations:21.1"
+  compile "io.github.graphql-java:graphql-java-annotations:21.2"
 }
 ```
 
@@ -47,7 +47,7 @@ dependencies {
 <dependency>
     <groupId>io.github.graphql-java</groupId>
     <artifactId>graphql-java-annotations</artifactId>
-    <version>21.1</version>
+    <version>21.2</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     implementation 'javax.validation:validation-api:1.1.0.Final'
-    implementation 'com.graphql-java:graphql-java:21.1'
+    implementation 'com.graphql-java:graphql-java:21.2'
     implementation 'com.graphql-java:graphql-java-extended-scalars:21.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
-version = 21.1
+version = 21.2


### PR DESCRIPTION
Upgrades graphql-java version to 21.2, which contains fixed OSGi metadata.