### PR TITLE
Add a `@GraphQLIgnore` annotation allowing field parameters to be ignored/excluded from a schema

### DIFF
--- a/src/main/java/graphql/annotations/annotationTypes/GraphQLIgnore.java
+++ b/src/main/java/graphql/annotations/annotationTypes/GraphQLIgnore.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations.annotationTypes;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.PARAMETER})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface GraphQLIgnore {
+  boolean value() default true;
+}

--- a/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/ArgumentBuilder.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/fieldBuilders/ArgumentBuilder.java
@@ -14,6 +14,7 @@ package graphql.annotations.processor.retrievers.fieldBuilders;
 
 import graphql.annotations.annotationTypes.GraphQLDefaultValue;
 import graphql.annotations.annotationTypes.GraphQLDescription;
+import graphql.annotations.annotationTypes.GraphQLIgnore;
 import graphql.annotations.annotationTypes.GraphQLName;
 import graphql.annotations.processor.ProcessingElementsContainer;
 import graphql.annotations.processor.exceptions.GraphQLAnnotationsException;
@@ -50,6 +51,7 @@ public class ArgumentBuilder implements Builder<List<GraphQLArgument>> {
         TypeFunction finalTypeFunction = typeFunction;
         List<GraphQLArgument> args = Arrays.stream(method.getParameters()).
                 filter(p -> !DataFetchingEnvironment.class.isAssignableFrom(p.getType())).
+                filter(p -> !p.isAnnotationPresent(GraphQLIgnore.class)).
                 map(parameter -> {
                     Class<?> t = parameter.getType();
                     graphql.schema.GraphQLInputType graphQLType = (GraphQLInputType) finalTypeFunction.buildType(true, t, parameter.getAnnotatedType(), container);

--- a/src/test/java/graphql/annotations/GraphQLIgnoredFieldParameterTest.java
+++ b/src/test/java/graphql/annotations/GraphQLIgnoredFieldParameterTest.java
@@ -1,0 +1,119 @@
+/**
+ * Copyright 2016 Yurii Rashkovskii
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ */
+package graphql.annotations;
+
+import static graphql.annotations.AnnotationsSchemaCreator.newAnnotationsSchema;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import graphql.annotations.annotationTypes.GraphQLField;
+import graphql.annotations.annotationTypes.GraphQLIgnore;
+import graphql.annotations.annotationTypes.GraphQLName;
+import graphql.annotations.processor.GraphQLAnnotations;
+import graphql.schema.GraphQLObjectType;
+import graphql.schema.GraphQLSchema;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+public class GraphQLIgnoredFieldParameterTest {
+    private AnnotationsSchemaCreator.Builder builder;
+    private GraphQLAnnotations graphQLAnnotations;
+
+    @BeforeMethod
+    public void setUp() {
+        graphQLAnnotations = new GraphQLAnnotations();
+        builder = newAnnotationsSchema().setAnnotationsProcessor(graphQLAnnotations);
+    }
+
+    public static class QueryTest1 {
+        @GraphQLField
+        public int foo(@GraphQLIgnore int bar) {
+            return 5;
+        }
+    }
+
+    @Test
+    public void build_Query1IsProvided_SchemaIsCreatedWithoutIgnoredFieldParameters() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest1.class).build();
+
+        // assert
+        GraphQLObjectType queryType = schema.getQueryType();
+        assertThat(queryType.getFieldDefinition("foo"), notNullValue());
+        assertThat(queryType.getFieldDefinition("foo").getArguments().size(), is(0));
+    }
+
+    public static class QueryTest2 {
+        @GraphQLField
+        public int foo(int bar, @GraphQLIgnore String baz, @GraphQLName("quuxAlias") long quux) {
+            return 5;
+        }
+    }
+
+    @Test
+    public void build_Query2IsProvided_SchemaIsCreatedWithoutIgnoredFieldParameters() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest2.class).build();
+
+        // assert
+        GraphQLObjectType queryType = schema.getQueryType();
+        assertThat(queryType.getFieldDefinition("foo"), notNullValue());
+        assertThat(queryType.getFieldDefinition("foo").getArguments().size(), is(2));
+        assertThat(queryType.getFieldDefinition("foo").getArgument("arg0"), notNullValue());
+        assertThat(queryType.getFieldDefinition("foo").getArgument("baz"), nullValue());
+        assertThat(queryType.getFieldDefinition("foo").getArgument("quuxAlias"), notNullValue());
+    }
+
+    public static class MutationTest1 {
+        @GraphQLField
+        public int foo(@GraphQLIgnore int bar) {
+            return 4;
+        }
+    }
+
+    @Test
+    public void build_Mutation1IsProvided_SchemaIsCreatedWithoutIgnoredFieldParameters() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest1.class).mutation(MutationTest1.class).build();
+
+        /// assert
+        GraphQLObjectType mutation = schema.getMutationType();
+        assertThat(mutation.getFieldDefinition("foo"), notNullValue());
+        assertThat(mutation.getFieldDefinition("foo").getArguments().size(), is(0));
+    }
+
+    public static class MutationTest2 {
+        @GraphQLField
+        public int foo(int bar, @GraphQLIgnore String baz, @GraphQLName("quuxAlias") long quux) {
+            return 4;
+        }
+    }
+
+    @Test
+    public void build_Mutation2IsProvided_SchemaIsCreatedWithoutIgnoredFieldParameters() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(QueryTest1.class).mutation(MutationTest2.class).build();
+
+        /// assert
+        GraphQLObjectType mutation = schema.getMutationType();
+        assertThat(mutation.getFieldDefinition("foo"), notNullValue());
+        assertThat(mutation.getFieldDefinition("foo").getArguments().size(), is(2));
+        assertThat(mutation.getFieldDefinition("foo").getArgument("arg0"), notNullValue());
+        assertThat(mutation.getFieldDefinition("foo").getArgument("baz"), nullValue());
+        assertThat(mutation.getFieldDefinition("foo").getArgument("quuxAlias"), notNullValue());
+    }
+}


### PR DESCRIPTION
This will enhance type safety in situations where the schema is built using `grapqhl-java` and `graphql-java-annotations`, then provided to a different library (e.g. `graphql-spring`) for execution.

Currently, oftentimes the runtime implementation of a schema (resolvers, controllers, etc.) can't implement some of the interfaces defining the schema, as the former requires runtime-specific arguments (context, environment, etc.). This means that an interface can change, and the schema will change as a result upon regeneration from the interfaces, but forgetting to change the runtime implementation won't be caught statically at compile-time, leading to eventual runtime errors.

With this change, interfaces can be modified to include those runtime-specific parameters, tagging them with `@GraphQLIgnore`, so that runtime classes can implement them.