### PR TITLE
Use actual graphql name on extending type

### DIFF
--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java
@@ -44,6 +44,7 @@ public class GraphQLExtensionsHandler {
 
     public List<GraphQLFieldDefinition> getExtensionFields(Class<?> object, List<String> definedFields, ProcessingElementsContainer container) throws CannotCastMemberException {
         List<GraphQLFieldDefinition> fields = new ArrayList<>();
+        String typeName = graphQLObjectInfoRetriever.getTypeName(object);
         if (container.getExtensionsTypeRegistry().containsKey(object)) {
             for (Class<?> aClass : container.getExtensionsTypeRegistry().get(object)) {
                 for (Method method : graphQLObjectInfoRetriever.getOrderedMethods(aClass)) {
@@ -51,7 +52,7 @@ public class GraphQLExtensionsHandler {
                         continue;
                     }
                     if (methodSearchAlgorithm.isFound(method)) {
-                        addExtensionField(fieldRetriever.getField(object.getSimpleName(), method, container), fields, definedFields);
+                        addExtensionField(fieldRetriever.getField(typeName, method, container), fields, definedFields);
                     }
                 }
                 for (Field field : getAllFields(aClass).values()) {
@@ -59,7 +60,7 @@ public class GraphQLExtensionsHandler {
                         continue;
                     }
                     if (fieldSearchAlgorithm.isFound(field)) {
-                        addExtensionField(fieldRetriever.getField(object.getSimpleName(), field, container), fields, definedFields);
+                        addExtensionField(fieldRetriever.getField(typeName, field, container), fields, definedFields);
                     }
                 }
             }


### PR DESCRIPTION
If a type is extended via a `GraphQLTypeExtension` annotation, the simple class name is used instead of checking whether a GraphQLName annotation is available; if the GraphQL name differs from the class name, the field cannot be fetched.

Example:

All the fields from the `GqlCurrentUser` class will be added with `CurrentUser` as the parent name. While handling the extension, the fields will be registered with `GqlCurrentUser` as the parent name, which does not match the actual parent.

```java
@GraphQLName(GqlCurrentUser.TYPE_NAME)
public class GqlCurrentUser {

  public static final String TYPE_NAME = "CurrentUser";

}

@GraphQLTypeExtension(GqlCurrentUser.class)
public class EventCurrentUserExtension {
}
```

https://github.com/Enigmatis/graphql-java-annotations/blob/74dd8c8e4da73b98927d988e4e62b12a733d6fd3/src/main/java/graphql/annotations/processor/typeBuilders/OutputObjectBuilder.java#L82

vs 

https://github.com/Enigmatis/graphql-java-annotations/blob/74dd8c8e4da73b98927d988e4e62b12a733d6fd3/src/main/java/graphql/annotations/processor/retrievers/GraphQLExtensionsHandler.java#L62