### PR TITLE
Updated secrets for publishing to maven central

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,5 +26,5 @@ jobs:
       run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
         MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USERTOKEN_USERNAME }}
-        MAVEN_CENTRAL_USERTOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_USERTOKEN_PASSWORD }}
+        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_USERTOKEN_PASSWORD }}
         MAVEN_CENTRAL_PGP_KEY: ${{ secrets.MAVEN_CENTRAL_PGP_KEY }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,6 +25,6 @@ jobs:
     - name: Publish with Gradle
       run: ./gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository
       env:
-        MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-        MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+        MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USERTOKEN_USERNAME }}
+        MAVEN_CENTRAL_USERTOKEN_PASSWORD: ${{ secrets.MAVEN_CENTRAL_USERTOKEN_PASSWORD }}
         MAVEN_CENTRAL_PGP_KEY: ${{ secrets.MAVEN_CENTRAL_PGP_KEY }}

--- a/build.gradle
+++ b/build.gradle
@@ -150,8 +150,8 @@ afterReleaseBuild.dependsOn nexusPublishing
 nexusPublishing {
     repositories {
         sonatype {
-            username = System.getenv("MAVEN_CENTRAL_USER")
-            password = System.getenv("MAVEN_CENTRAL_PASSWORD")
+            username = System.getenv("MAVEN_CENTRAL_USERTOKEN_USERNAME")
+            password = System.getenv("MAVEN_CENTRAL_USERTOKEN_PASSWORD")
         }
     }
 }


### PR DESCRIPTION
The reasoning for renaming the secrets (versus just updating their content) is to highlight the fact that these are user tokens as per the recommendations from sontaype: https://central.sonatype.org/publish/publish-gradle/#introduction 

This should resolve: #305