### PR TITLE
Update graphql-java 26.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you would like to use a tool that creates a graphql spring boot server using 
 
 ```groovy
 dependencies {
-  compile "io.github.graphql-java:graphql-java-annotations:24.3"
+  compile "io.github.graphql-java:graphql-java-annotations:26.0"
 }
 ```
 
@@ -47,7 +47,7 @@ dependencies {
 <dependency>
     <groupId>io.github.graphql-java</groupId>
     <artifactId>graphql-java-annotations</artifactId>
-    <version>24.3</version>
+    <version>26.0</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ gradle.projectsEvaluated {
 
 dependencies {
     implementation 'javax.validation:validation-api:1.1.0.Final'
-    implementation 'com.graphql-java:graphql-java:24.3'
+    implementation 'com.graphql-java:graphql-java:26.0'
     implementation 'com.graphql-java:graphql-java-extended-scalars:24.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,4 @@ org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 
-version = 24.3
+version = 26.0

--- a/src/main/java/graphql/annotations/AnnotationsSchemaCreator.java
+++ b/src/main/java/graphql/annotations/AnnotationsSchemaCreator.java
@@ -20,8 +20,8 @@ import graphql.annotations.processor.GraphQLAnnotations;
 import graphql.annotations.processor.typeFunctions.TypeFunction;
 import graphql.relay.Relay;
 import graphql.schema.GraphQLDirective;
+import graphql.schema.GraphQLNamedType;
 import graphql.schema.GraphQLSchema;
-import graphql.schema.GraphQLType;
 import graphql.schema.SchemaTransformer;
 
 import java.util.*;
@@ -247,7 +247,7 @@ public class AnnotationsSchemaCreator {
             Set<GraphQLDirective> directives = directivesObjectList.stream().map(dir -> graphQLAnnotations.directive(dir)).collect(Collectors.toSet());
             directiveContainerClasses.forEach(dir -> directives.addAll(graphQLAnnotations.directives(dir)));
 
-            Set<GraphQLType> additionalTypes = additionalTypesList.stream().map(additionalType ->
+            Set<GraphQLNamedType> additionalTypes = additionalTypesList.stream().map(additionalType ->
                     additionalType.isInterface() ?
                             graphQLAnnotations.generateInterface(additionalType) : graphQLAnnotations.object(additionalType)).collect(Collectors.toSet());
 


### PR DESCRIPTION
## Summary
Updates the graphql-java dependency to 26.0 and makes a minor code adjustment to support it.

## Type
- [ ] Bug fix
- [X] Feature
- [ ] Docs
- [ ] Build/CI

## Checklist
- [X ] Includes tests (all existing tests pass)
- [X] Updates documentation if needed
- [ ] Linked to issue: Fixes #____

## Notes for reviewers
No additional notes.
