### PR TITLE
Allow Inheritance of Multiple Classes and Interfaces for Query and Mutation Classes

### DIFF
--- a/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
+++ b/src/main/java/graphql/annotations/processor/retrievers/GraphQLObjectInfoRetriever.java
@@ -23,7 +23,9 @@ import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import static graphql.annotations.processor.util.NamingKit.toGraphqlName;
@@ -36,10 +38,27 @@ public class GraphQLObjectInfoRetriever {
         return toGraphqlName(name == null ? objectClass.getSimpleName() : name.value());
     }
 
-    public List<Method> getOrderedMethods(Class c) {
-        return Arrays.stream(c.getMethods())
+    public List<Method> getOrderedMethods(Class<?> c) {
+        var methods = new LinkedHashMap<String, Method>();
+        collectMethods(c, methods);
+        return methods.values().stream()
                 .sorted(Comparator.comparing(Method::getName))
                 .collect(Collectors.toList());
+    }
+
+    private void collectMethods(Class<?> c, Map<String, Method> methods) {
+        if (c == null) {
+            return;
+        }
+
+        Arrays.stream(c.getDeclaredMethods())
+                .forEach(method -> methods.putIfAbsent(method.getName(), method));
+
+        for (Class<?> iface : c.getInterfaces()) {
+            collectMethods(iface, methods);
+        }
+
+        collectMethods(c.getSuperclass(), methods);
     }
 
     public Boolean isGraphQLField(AnnotatedElement element) {
@@ -49,6 +68,5 @@ public class GraphQLObjectInfoRetriever {
         }
         return annotation.value();
     }
-
 
 }

--- a/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
+++ b/src/test/java/graphql/annotations/AnnotationsSchemaCreatorTest.java
@@ -96,6 +96,63 @@ public class AnnotationsSchemaCreatorTest {
         assertThat(mutationType.getFieldDefinitions().size(), is(1));
     }
 
+    public interface BaseQuery {
+        @GraphQLField
+        int baseQuery();
+    }
+
+    public interface IntermediateQuery extends BaseQuery {
+        @GraphQLField
+        int intermediateQuery();
+    }
+
+    public interface InheritedQuery extends IntermediateQuery {
+        @GraphQLField
+        int inheritedQuery();
+    }
+
+    public interface BaseMutation {
+        @GraphQLField
+        int baseMutation();
+    }
+
+    public static class ParentMutation implements BaseMutation {
+        @Override
+        public int baseMutation() {
+            return 6;
+        }
+
+        @GraphQLField
+        public int parentMutation() {
+            return 7;
+        }
+    }
+
+    public static class InheritedMutation extends ParentMutation {
+        @GraphQLField
+        public int inheritedMutation() {
+            return 8;
+        }
+    }
+
+    @Test
+    public void build_QueryAndMutationWithInheritedTypes_SchemaContainsInheritedFields() {
+        // arrange + act
+        GraphQLSchema schema = builder.query(InheritedQuery.class).mutation(InheritedMutation.class).build();
+        GraphQLObjectType queryType = schema.getQueryType();
+        GraphQLObjectType mutationType = schema.getMutationType();
+
+        // assert
+        assertThat(queryType.getFieldDefinition("baseQuery"), notNullValue());
+        assertThat(queryType.getFieldDefinition("intermediateQuery"), notNullValue());
+        assertThat(queryType.getFieldDefinition("inheritedQuery"), notNullValue());
+        assertThat(queryType.getFieldDefinitions().size(), is(3));
+        assertThat(mutationType.getFieldDefinition("baseMutation"), notNullValue());
+        assertThat(mutationType.getFieldDefinition("parentMutation"), notNullValue());
+        assertThat(mutationType.getFieldDefinition("inheritedMutation"), notNullValue());
+        assertThat(mutationType.getFieldDefinitions().size(), is(3));
+    }
+
     public static class SubscriptionTest {
         @GraphQLField
         public int subscribe() {


### PR DESCRIPTION
## Summary
Modifies functionality of two methods in AnnotationsSchemaCreator: queries and mutations, and allows the classes and interfaces that are passed in to have any super classes and extended interfaces to be examined for additional fields that should be added to the schema. This matches behavior of GraphQL objects.

This allows for better organization of source code (in my case, the interfaces containing queries and mutations have grown to be extremely unwieldy and need to be broken up by the major components in the application. This provides for that.

## Type
- [ ] Bug fix
- [X] Feature
- [ ] Docs
- [ ] Build/CI

## Checklist
- [X] Includes tests (or reason why not applicable)
- [ ] Updates documentation if needed
- [ ] Linked to issue: Fixes #____

## Notes for reviewers
Should be entirely backwards compatible, it was a drop-in replacement in my case.
